### PR TITLE
feat: 名刺データの型定義と共有モデル作成

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,44 @@
+/** AI が生成する議論ネタ */
+export interface Topic {
+  readonly id: string;
+  readonly text: string;
+  readonly category: string;
+}
+
+/** ネタ＋ユーザーの立場 */
+export interface TopicWithStance {
+  readonly topic: Topic;
+  readonly agrees: boolean;
+}
+
+/** 名刺データ */
+export interface MeishiData {
+  readonly id: string;
+  readonly prefecture: string;
+  readonly topics: ReadonlyArray<TopicWithStance>;
+  readonly createdAt: string; // ISO 8601
+}
+
+/** ネタごとの比較結果 */
+export interface TopicMatch {
+  readonly topicText: string;
+  readonly category: string;
+  readonly myStance: boolean;
+  readonly partnerStance: boolean;
+  readonly isMatch: boolean;
+}
+
+/** 2人の名刺比較結果 */
+export interface ComparisonResult {
+  readonly myMeishi: MeishiData;
+  readonly partnerMeishi: MeishiData;
+  readonly matches: ReadonlyArray<TopicMatch>;
+  readonly matchCount: number;
+  readonly mismatchCount: number;
+}
+
+/** AI ネタ生成APIのレスポンス */
+export interface GenerateTopicsResponse {
+  readonly topics: ReadonlyArray<Topic>;
+  readonly prefecture: string;
+}


### PR DESCRIPTION
## Summary
- `src/types/index.ts` に全共有型を定義
- MeishiData, Topic, TopicWithStance, ComparisonResult, TopicMatch, GenerateTopicsResponse
- 全型を `readonly` + `ReadonlyArray` でイミュータブルに定義
- フロントエンド・サーバー両方から `import` 可能

## Test plan
- [ ] `npx tsc -b` が型エラーなく通る
- [ ] フロント側（`src/`）からimportできる
- [ ] サーバー側（`server/`）からimportできる

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)