### PR TITLE
feat: 名刺比較ロジック（一致・不一致判定） (#5)

### DIFF
--- a/src/utils/comparison.test.ts
+++ b/src/utils/comparison.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { compareMeishi } from "./comparison";
+import type { MeishiData } from "../types";
+
+const createMeishi = (
+  prefecture: string,
+  stances: { text: string; category: string; agrees: boolean }[]
+): MeishiData => ({
+  id: crypto.randomUUID(),
+  prefecture,
+  topics: stances.map((s) => ({
+    topic: { id: crypto.randomUUID(), text: s.text, category: s.category },
+    agrees: s.agrees,
+  })),
+  createdAt: new Date().toISOString(),
+});
+
+describe("compareMeishi", () => {
+  it("完全一致: すべてのネタで立場が同じ場合", () => {
+    const topics = [
+      { text: "たこ焼きは主食", category: "食文化", agrees: true },
+      { text: "エスカレーターは右に立つ", category: "習慣", agrees: false },
+      { text: "〜やねん は標準語", category: "方言", agrees: true },
+    ];
+    const my = createMeishi("大阪府", topics);
+    const partner = createMeishi("大阪府", topics);
+
+    const result = compareMeishi(my, partner);
+
+    expect(result.matchCount).toBe(3);
+    expect(result.mismatchCount).toBe(0);
+    expect(result.matches).toHaveLength(3);
+    expect(result.matches.every((m) => m.isMatch)).toBe(true);
+    expect(result.myMeishi).toBe(my);
+    expect(result.partnerMeishi).toBe(partner);
+  });
+
+  it("完全不一致: すべてのネタで立場が異なる場合", () => {
+    const my = createMeishi("大阪府", [
+      { text: "たこ焼きは主食", category: "食文化", agrees: true },
+      { text: "エスカレーターは右に立つ", category: "習慣", agrees: true },
+    ]);
+    const partner = createMeishi("東京都", [
+      { text: "たこ焼きは主食", category: "食文化", agrees: false },
+      { text: "エスカレーターは右に立つ", category: "習慣", agrees: false },
+    ]);
+
+    const result = compareMeishi(my, partner);
+
+    expect(result.matchCount).toBe(0);
+    expect(result.mismatchCount).toBe(2);
+    expect(result.matches.every((m) => !m.isMatch)).toBe(true);
+  });
+
+  it("混合パターン: 一致と不一致が混在する場合", () => {
+    const my = createMeishi("大阪府", [
+      { text: "たこ焼きは主食", category: "食文化", agrees: true },
+      { text: "エスカレーターは右に立つ", category: "習慣", agrees: true },
+      { text: "〜やねん は標準語", category: "方言", agrees: false },
+    ]);
+    const partner = createMeishi("京都府", [
+      { text: "たこ焼きは主食", category: "食文化", agrees: true },
+      { text: "エスカレーターは右に立つ", category: "習慣", agrees: false },
+      { text: "〜やねん は標準語", category: "方言", agrees: false },
+    ]);
+
+    const result = compareMeishi(my, partner);
+
+    expect(result.matchCount).toBe(2);
+    expect(result.mismatchCount).toBe(1);
+    expect(result.matchCount + result.mismatchCount).toBe(3);
+  });
+
+  it("matchCount + mismatchCount = 全ネタ数 を満たす", () => {
+    const my = createMeishi("大阪府", [
+      { text: "ネタ1", category: "食文化", agrees: true },
+      { text: "ネタ2", category: "習慣", agrees: false },
+      { text: "ネタ3", category: "方言", agrees: true },
+      { text: "ネタ4", category: "文化", agrees: false },
+      { text: "ネタ5", category: "観光", agrees: true },
+    ]);
+    const partner = createMeishi("東京都", [
+      { text: "ネタ1", category: "食文化", agrees: false },
+      { text: "ネタ2", category: "習慣", agrees: false },
+      { text: "ネタ3", category: "方言", agrees: false },
+      { text: "ネタ4", category: "文化", agrees: true },
+      { text: "ネタ5", category: "観光", agrees: true },
+    ]);
+
+    const result = compareMeishi(my, partner);
+
+    expect(result.matchCount + result.mismatchCount).toBe(5);
+    expect(result.matches).toHaveLength(5);
+  });
+
+  it("各TopicMatchが正しいフィールドを持つ", () => {
+    const my = createMeishi("大阪府", [
+      { text: "たこ焼きは主食", category: "食文化", agrees: true },
+    ]);
+    const partner = createMeishi("東京都", [
+      { text: "たこ焼きは主食", category: "食文化", agrees: false },
+    ]);
+
+    const result = compareMeishi(my, partner);
+    const match = result.matches[0];
+
+    expect(match.topicText).toBe("たこ焼きは主食");
+    expect(match.category).toBe("食文化");
+    expect(match.myStance).toBe(true);
+    expect(match.partnerStance).toBe(false);
+    expect(match.isMatch).toBe(false);
+  });
+
+  it("ネタの順番が異なっても正しく比較する（インデックスベース）", () => {
+    const my = createMeishi("大阪府", [
+      { text: "ネタA", category: "食文化", agrees: true },
+      { text: "ネタB", category: "習慣", agrees: false },
+    ]);
+    const partner = createMeishi("東京都", [
+      { text: "ネタA", category: "食文化", agrees: true },
+      { text: "ネタB", category: "習慣", agrees: true },
+    ]);
+
+    const result = compareMeishi(my, partner);
+
+    expect(result.matchCount).toBe(1);
+    expect(result.mismatchCount).toBe(1);
+  });
+});

--- a/src/utils/comparison.ts
+++ b/src/utils/comparison.ts
@@ -1,0 +1,39 @@
+import type {
+  MeishiData,
+  ComparisonResult,
+  TopicMatch,
+} from "../types";
+
+/**
+ * 2人の名刺データを比較し、各ネタの立場の一致・不一致を判定する。
+ * インデックスベースで対応するネタ同士を比較する。
+ */
+export const compareMeishi = (
+  myMeishi: MeishiData,
+  partnerMeishi: MeishiData
+): ComparisonResult => {
+  const matches: ReadonlyArray<TopicMatch> = myMeishi.topics.map(
+    (myTopic, index) => {
+      const partnerTopic = partnerMeishi.topics[index];
+      const isMatch = myTopic.agrees === partnerTopic.agrees;
+
+      return {
+        topicText: myTopic.topic.text,
+        category: myTopic.topic.category,
+        myStance: myTopic.agrees,
+        partnerStance: partnerTopic.agrees,
+        isMatch,
+      };
+    }
+  );
+
+  const matchCount = matches.filter((m) => m.isMatch).length;
+
+  return {
+    myMeishi,
+    partnerMeishi,
+    matches,
+    matchCount,
+    mismatchCount: matches.length - matchCount,
+  };
+};


### PR DESCRIPTION
## Summary
- 2人の名刺データを比較し、各ネタの立場が一致するか不一致かを判定する `compareMeishi` 関数を実装
- `ComparisonResult` 型（`TopicMatch[]` + `matchCount` / `mismatchCount`）を返却
- ユニットテスト6ケースを追加（完全一致、完全不一致、混合パターン、合計数検証、フィールド検証、順番確認）

## Test plan
- [x] 完全一致パターン: 全ネタで立場が同じ → matchCount = 全数, mismatchCount = 0
- [x] 完全不一致パターン: 全ネタで立場が異なる → matchCount = 0
- [x] 混合パターン: 一致・不一致が混在
- [x] matchCount + mismatchCount = 全ネタ数 の不変条件
- [x] TopicMatch の各フィールド（topicText, category, myStance, partnerStance, isMatch）の正確性
- [x] 全テスト合格確認済み（10/10 pass）

Closes #5