### PR TITLE
feat: Socket.IO交換マッチングサーバー (#13)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,9 @@
         "express": "^5.2.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router-dom": "^7.13.1"
+        "react-router-dom": "^7.13.1",
+        "socket.io": "^4.8.3",
+        "socket.io-client": "^4.8.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -1380,6 +1382,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1973,7 +1981,6 @@
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
       "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2043,7 +2050,6 @@
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -2126,6 +2132,15 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2679,6 +2694,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.7",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
@@ -3177,6 +3201,101 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
+      "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -5306,6 +5425,105 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.18.3"
+      }
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
+      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5628,7 +5846,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -5917,6 +6134,35 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "express": "^5.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^7.13.1"
+    "react-router-dom": "^7.13.1",
+    "socket.io": "^4.8.3",
+    "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/server/socket/exchangeHandler.test.ts
+++ b/server/socket/exchangeHandler.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { createServer } from "node:http";
+import type { Server as HttpServer } from "node:http";
+import { io as ioClient } from "socket.io-client";
+import type { Socket as ClientSocket } from "socket.io-client";
+import type { Server as SocketIOServer } from "socket.io";
+import type { MeishiData } from "../../src/types/index";
+import { setupExchangeSocket } from "./exchangeHandler";
+
+const createMeishi = (id: string, prefecture: string): MeishiData => ({
+  id,
+  prefecture,
+  topics: [
+    {
+      topic: { id: "t1", text: "たこ焼きは主食", category: "食文化" },
+      agrees: true,
+    },
+  ],
+  createdAt: new Date().toISOString(),
+});
+
+/** イベントを待機する。タイムアウト時は reject する */
+const waitForEvent = <T>(
+  socket: ClientSocket,
+  event: string,
+  timeoutMs = 5000,
+): Promise<T> =>
+  new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`Timeout waiting for "${event}"`)),
+      timeoutMs,
+    );
+    socket.once(event, (data: T) => {
+      clearTimeout(timer);
+      resolve(data);
+    });
+  });
+
+/**
+ * 指定時間内にイベントが届かないことを確認する。
+ * イベントが届けば true、届かなければ false を返す。
+ */
+const didReceiveEvent = (
+  socket: ClientSocket,
+  event: string,
+  waitMs = 300,
+): Promise<boolean> =>
+  new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      socket.off(event, handler);
+      resolve(false);
+    }, waitMs);
+    const handler = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    socket.once(event, handler);
+  });
+
+const connectClient = (port: number): ClientSocket =>
+  ioClient(`http://localhost:${port}`, {
+    transports: ["websocket"],
+    forceNew: true,
+  });
+
+const waitForConnect = (socket: ClientSocket): Promise<void> =>
+  new Promise((resolve) => {
+    if (socket.connected) {
+      resolve();
+      return;
+    }
+    socket.on("connect", () => resolve());
+  });
+
+const joinRoom = (client: ClientSocket): Promise<void> =>
+  new Promise((resolve) => {
+    client.emit("join-exchange", undefined, () => resolve());
+  });
+
+describe("ExchangeSocketServer", () => {
+  let httpServer: HttpServer;
+  let ioServer: SocketIOServer;
+  let port: number;
+  const clients: ClientSocket[] = [];
+
+  const createAndTrackClient = async (): Promise<ClientSocket> => {
+    const client = connectClient(port);
+    clients.push(client);
+    await waitForConnect(client);
+    return client;
+  };
+
+  beforeAll(
+    () =>
+      new Promise<void>((resolve) => {
+        httpServer = createServer();
+        ioServer = setupExchangeSocket(httpServer);
+        httpServer.listen(0, () => {
+          const addr = httpServer.address();
+          port = typeof addr === "object" && addr !== null ? addr.port : 0;
+          resolve();
+        });
+      }),
+  );
+
+  afterEach(() => {
+    for (const client of clients) {
+      client.disconnect();
+    }
+    clients.length = 0;
+  });
+
+  afterAll(
+    () =>
+      new Promise<void>((resolve) => {
+        ioServer.close();
+        httpServer.close(() => resolve());
+      }),
+  );
+
+  // --- ルーム参加・退出 ---
+
+  it("join-exchange でルームに参加できる", async () => {
+    const client = await createAndTrackClient();
+
+    const result = await new Promise<{ status: string }>((resolve) => {
+      client.emit("join-exchange", undefined, (res: { status: string }) => {
+        resolve(res);
+      });
+    });
+
+    expect(result.status).toBe("joined");
+  });
+
+  it("leave-exchange でルームから退出できる", async () => {
+    const client = await createAndTrackClient();
+    await joinRoom(client);
+
+    const result = await new Promise<{ status: string }>((resolve) => {
+      client.emit("leave-exchange", undefined, (res: { status: string }) => {
+        resolve(res);
+      });
+    });
+
+    expect(result.status).toBe("left");
+  });
+
+  // --- マッチング成功 ---
+
+  it("2クライアントが3秒以内にbumpすると matched イベントが両方に届く", async () => {
+    const clientA = await createAndTrackClient();
+    const clientB = await createAndTrackClient();
+    const meishiA = createMeishi("a1", "大阪府");
+    const meishiB = createMeishi("b1", "東京都");
+
+    await joinRoom(clientA);
+    await joinRoom(clientB);
+
+    const now = Date.now();
+
+    const matchedA = waitForEvent<{ partnerMeishi: MeishiData }>(clientA, "matched");
+    const matchedB = waitForEvent<{ partnerMeishi: MeishiData }>(clientB, "matched");
+
+    clientA.emit("bump", { timestamp: now, meishi: meishiA });
+    clientB.emit("bump", { timestamp: now + 500, meishi: meishiB });
+
+    const [resultA, resultB] = await Promise.all([matchedA, matchedB]);
+
+    expect(resultA.partnerMeishi.id).toBe("b1");
+    expect(resultA.partnerMeishi.prefecture).toBe("東京都");
+    expect(resultB.partnerMeishi.id).toBe("a1");
+    expect(resultB.partnerMeishi.prefecture).toBe("大阪府");
+  });
+
+  // --- マッチング不成立 ---
+
+  it("単独の bump ではマッチングが成立しない", async () => {
+    const client = await createAndTrackClient();
+    const meishi = createMeishi("solo1", "北海道");
+
+    await joinRoom(client);
+
+    client.emit("bump", { timestamp: Date.now(), meishi });
+
+    const received = await didReceiveEvent(client, "matched");
+    expect(received).toBe(false);
+  });
+
+  it("タイムスタンプ差が3秒超の場合はマッチングしない", async () => {
+    const clientA = await createAndTrackClient();
+    const clientB = await createAndTrackClient();
+    const meishiA = createMeishi("a2", "大阪府");
+    const meishiB = createMeishi("b2", "東京都");
+
+    await joinRoom(clientA);
+    await joinRoom(clientB);
+
+    const now = Date.now();
+
+    clientA.emit("bump", { timestamp: now, meishi: meishiA });
+    // 4秒差 — マッチングウィンドウ外
+    clientB.emit("bump", { timestamp: now + 4000, meishi: meishiB });
+
+    const receivedA = await didReceiveEvent(clientA, "matched");
+    const receivedB = await didReceiveEvent(clientB, "matched");
+
+    expect(receivedA).toBe(false);
+    expect(receivedB).toBe(false);
+  });
+
+  // --- データクリア ---
+
+  it("マッチング後は bump データがクリアされる（再利用されない）", async () => {
+    const clientA = await createAndTrackClient();
+    const clientB = await createAndTrackClient();
+    const clientC = await createAndTrackClient();
+    const meishiA = createMeishi("a3", "大阪府");
+    const meishiB = createMeishi("b3", "東京都");
+    const meishiC = createMeishi("c3", "福岡県");
+
+    await joinRoom(clientA);
+    await joinRoom(clientB);
+    await joinRoom(clientC);
+
+    const now = Date.now();
+
+    // A と B がマッチング
+    const matchedA = waitForEvent<{ partnerMeishi: MeishiData }>(clientA, "matched");
+    const matchedB = waitForEvent<{ partnerMeishi: MeishiData }>(clientB, "matched");
+
+    clientA.emit("bump", { timestamp: now, meishi: meishiA });
+    clientB.emit("bump", { timestamp: now + 100, meishi: meishiB });
+
+    await Promise.all([matchedA, matchedB]);
+
+    // C が bump — A のデータはクリア済みなのでマッチングしない
+    clientC.emit("bump", { timestamp: now + 200, meishi: meishiC });
+
+    const receivedC = await didReceiveEvent(clientC, "matched");
+    expect(receivedC).toBe(false);
+  });
+
+  // --- バリデーション ---
+
+  it("bump に meishi が含まれない場合はエラーが返る", async () => {
+    const client = await createAndTrackClient();
+    await joinRoom(client);
+
+    const error = waitForEvent<{ message: string }>(client, "error");
+
+    client.emit("bump", { timestamp: Date.now() });
+
+    const result = await error;
+    expect(result.message).toBeDefined();
+  });
+});

--- a/server/socket/exchangeHandler.ts
+++ b/server/socket/exchangeHandler.ts
@@ -1,0 +1,131 @@
+import { Server as SocketIOServer } from "socket.io";
+import type { Server as HttpServer } from "node:http";
+import type { MeishiData } from "../../src/types/index";
+
+/** bump イベントで保持するセッションデータ（イミュータブル） */
+interface BumpSession {
+  readonly socketId: string;
+  readonly timestamp: number;
+  readonly meishi: MeishiData;
+}
+
+/** マッチング判定のタイムスタンプ許容差（ミリ秒） */
+const MATCH_WINDOW_MS = 3000;
+
+/** 交換ルーム名 */
+const EXCHANGE_ROOM = "exchange-room";
+
+/**
+ * 新しい bump に対してマッチング相手を探す。
+ * タイムスタンプ差が MATCH_WINDOW_MS 以内の最初の相手を返す。
+ */
+const findMatch = (
+  pendingBumps: Map<string, BumpSession>,
+  incomingSession: BumpSession,
+): BumpSession | undefined => {
+  for (const [socketId, session] of pendingBumps) {
+    if (socketId === incomingSession.socketId) {
+      continue;
+    }
+    const diff = Math.abs(session.timestamp - incomingSession.timestamp);
+    if (diff <= MATCH_WINDOW_MS) {
+      return session;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * bump イベントのペイロードを検証する。
+ * meishi と timestamp が必須。
+ */
+const validateBumpPayload = (
+  data: unknown,
+): data is { timestamp: number; meishi: MeishiData } => {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+  const payload = data as Record<string, unknown>;
+  return (
+    typeof payload.timestamp === "number" &&
+    typeof payload.meishi === "object" &&
+    payload.meishi !== null
+  );
+};
+
+/**
+ * Socket.IO サーバーを既存の HTTP サーバーにアタッチする。
+ * server/index.ts からは `setupExchangeSocket(httpServer)` で呼び出す。
+ *
+ * 待機中の bump セッションはインスタンスごとの Map で管理する。
+ */
+export const setupExchangeSocket = (httpServer: HttpServer): SocketIOServer => {
+  const pendingBumps: Map<string, BumpSession> = new Map();
+
+  const io = new SocketIOServer(httpServer, {
+    cors: {
+      origin: "*",
+      methods: ["GET", "POST"],
+    },
+  });
+
+  io.on("connection", (socket) => {
+    /** ルーム参加 */
+    socket.on("join-exchange", (_data: unknown, callback?: (res: { status: string }) => void) => {
+      socket.join(EXCHANGE_ROOM);
+      if (typeof callback === "function") {
+        callback({ status: "joined" });
+      }
+    });
+
+    /** ルーム退出 */
+    socket.on("leave-exchange", (_data: unknown, callback?: (res: { status: string }) => void) => {
+      socket.leave(EXCHANGE_ROOM);
+      pendingBumps.delete(socket.id);
+      if (typeof callback === "function") {
+        callback({ status: "left" });
+      }
+    });
+
+    /** bump イベント処理 */
+    socket.on("bump", (data: unknown) => {
+      if (!validateBumpPayload(data)) {
+        socket.emit("error", {
+          message: "bump イベントには timestamp と meishi が必要です",
+        });
+        return;
+      }
+
+      const incomingSession: BumpSession = {
+        socketId: socket.id,
+        timestamp: data.timestamp,
+        meishi: data.meishi,
+      };
+
+      const partner = findMatch(pendingBumps, incomingSession);
+
+      if (partner !== undefined) {
+        // マッチング成立 — 両者に相手の名刺データを送信
+        pendingBumps.delete(partner.socketId);
+        pendingBumps.delete(socket.id);
+
+        io.to(partner.socketId).emit("matched", {
+          partnerMeishi: incomingSession.meishi,
+        });
+        socket.emit("matched", {
+          partnerMeishi: partner.meishi,
+        });
+      } else {
+        // マッチング相手なし — 待機リストに追加
+        pendingBumps.set(socket.id, incomingSession);
+      }
+    });
+
+    /** 切断時のクリーンアップ */
+    socket.on("disconnect", () => {
+      pendingBumps.delete(socket.id);
+    });
+  });
+
+  return io;
+};


### PR DESCRIPTION
## Summary
- Socket.IOによるぶつけ交換マッチングサーバーを実装（`server/socket/exchangeHandler.ts`）
- `setupExchangeSocket(httpServer)` 関数で既存のHTTPサーバーにSocket.IOをアタッチ
- インメモリMapでbumpセッションを管理し、タイムスタンプ差3秒以内の2クライアントをペアリング
- イベント: `join-exchange`, `leave-exchange`, `bump` → `matched`, `error`
- vitest + socket.io-clientによる統合テスト7件を追加

## 変更ファイル
- `server/socket/exchangeHandler.ts` — マッチングロジック本体
- `server/socket/exchangeHandler.test.ts` — 統合テスト
- `package.json` / `package-lock.json` — socket.io, socket.io-client 追加

## Test plan
- [x] 2クライアントが3秒以内にbump → matched イベントが両方に届く
- [x] 単独のbumpではマッチングが成立しない
- [x] タイムスタンプ差が3秒超の場合はマッチングしない
- [x] マッチング後はbumpデータがクリアされる（再利用されない）
- [x] join-exchange / leave-exchange のルーム参加・退出
- [x] bump に meishi が含まれない場合はエラーが返る
- [x] 全テスト（23件）がパス

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)