### PR TITLE
feat: 共有画面（QRコード・URL表示） (#10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.1",
@@ -3738,6 +3739,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1",

--- a/src/pages/SharePage.test.tsx
+++ b/src/pages/SharePage.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { SharePage } from "./SharePage";
+import type { MeishiData } from "../types";
+
+const mockMeishi: MeishiData = {
+  id: "test-id",
+  prefecture: "大阪府",
+  topics: [
+    {
+      topic: { id: "1", text: "たこ焼きは主食", category: "食文化" },
+      agrees: true,
+    },
+  ],
+  createdAt: "2026-03-14T00:00:00.000Z",
+};
+
+const renderWithRouter = (state?: Record<string, unknown>) =>
+  render(
+    <MemoryRouter initialEntries={[{ pathname: "/share", state }]}>
+      <SharePage />
+    </MemoryRouter>
+  );
+
+describe("SharePage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("名刺データがない場合はエラーメッセージを表示する", () => {
+    renderWithRouter();
+    expect(screen.getByText("名刺データがありません")).toBeDefined();
+    expect(screen.getByText("名刺を作る")).toBeDefined();
+  });
+
+  it("名刺データがある場合はQRコードと共有URLを表示する", () => {
+    renderWithRouter({ meishi: mockMeishi });
+    expect(screen.getByText("名刺を共有しよう")).toBeDefined();
+    expect(screen.getByText("URLをコピー")).toBeDefined();
+    // QRコードのSVGが存在する
+    const svg = document.querySelector("svg");
+    expect(svg).not.toBeNull();
+  });
+
+  it("共有URLに名刺データが含まれている", () => {
+    renderWithRouter({ meishi: mockMeishi });
+    const urlElement = document.querySelector(".break-all");
+    expect(urlElement?.textContent).toContain("/receive?d=");
+  });
+
+  it("コピーボタンをクリックするとクリップボードにコピーされる", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+
+    renderWithRouter({ meishi: mockMeishi });
+    const copyButton = screen.getByText("URLをコピー");
+    fireEvent.click(copyButton);
+
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining("/receive?d=")
+    );
+  });
+
+  it("交換画面への導線が表示される", () => {
+    renderWithRouter({ meishi: mockMeishi });
+    expect(screen.getByText("ぶつけて交換する")).toBeDefined();
+  });
+});

--- a/src/pages/SharePage.tsx
+++ b/src/pages/SharePage.tsx
@@ -1,3 +1,115 @@
+import { useCallback, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { QRCodeSVG } from "qrcode.react";
+import { toShareUrl } from "../utils/meishiEncoder";
+import type { MeishiData } from "../types";
+
 export function SharePage() {
-  return <div>共有</div>;
+  const location = useLocation();
+  const navigate = useNavigate();
+  const meishi = location.state?.meishi as MeishiData | undefined;
+  const [copied, setCopied] = useState(false);
+
+  const shareUrl = meishi ? toShareUrl(meishi) : "";
+
+  const handleCopy = useCallback(async () => {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // フォールバック: 古いブラウザ対応
+      const textArea = document.createElement("textarea");
+      textArea.value = shareUrl;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textArea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [shareUrl]);
+
+  const handleNativeShare = useCallback(async () => {
+    if (!navigator.share || !shareUrl) return;
+    try {
+      await navigator.share({
+        title: "地元名刺",
+        text: `${meishi?.prefecture}の地元名刺を見てね！`,
+        url: shareUrl,
+      });
+    } catch {
+      // ユーザーがキャンセルした場合は何もしない
+    }
+  }, [shareUrl, meishi?.prefecture]);
+
+  if (!meishi) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] px-4">
+        <p className="text-gray-600 text-lg mb-4">名刺データがありません</p>
+        <button
+          onClick={() => navigate("/")}
+          className="px-6 py-3 bg-blue-500 text-white rounded-xl font-bold"
+        >
+          名刺を作る
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center px-4 py-8 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-2">名刺を共有しよう</h1>
+      <p className="text-gray-500 text-sm mb-8">
+        QRコードを見せるか、URLを送ってね
+      </p>
+
+      {/* QRコード */}
+      <div className="bg-white p-6 rounded-2xl shadow-lg mb-8">
+        <QRCodeSVG
+          value={shareUrl}
+          size={220}
+          level="M"
+          includeMargin
+        />
+      </div>
+
+      {/* 共有URL表示 & コピー */}
+      <div className="w-full mb-6">
+        <div
+          onClick={handleCopy}
+          className="w-full p-4 bg-gray-100 rounded-xl text-sm text-gray-700 break-all cursor-pointer hover:bg-gray-200 transition-colors"
+        >
+          {shareUrl}
+        </div>
+        <button
+          onClick={handleCopy}
+          className={`w-full mt-3 py-3 rounded-xl font-bold text-white transition-colors ${
+            copied ? "bg-green-500" : "bg-blue-500 hover:bg-blue-600"
+          }`}
+        >
+          {copied ? "コピーしました！" : "URLをコピー"}
+        </button>
+      </div>
+
+      {/* ネイティブ共有（対応端末のみ） */}
+      {typeof navigator !== "undefined" && "share" in navigator && (
+        <button
+          onClick={handleNativeShare}
+          className="w-full py-3 bg-purple-500 hover:bg-purple-600 text-white rounded-xl font-bold mb-6 transition-colors"
+        >
+          共有メニューで送る
+        </button>
+      )}
+
+      {/* 交換画面への導線 */}
+      <button
+        onClick={() => navigate("/exchange", { state: { meishi } })}
+        className="w-full py-3 border-2 border-blue-500 text-blue-500 rounded-xl font-bold hover:bg-blue-50 transition-colors"
+      >
+        ぶつけて交換する
+      </button>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- 名刺完成後にQRコードと共有URLを表示する `SharePage` を実装
- qrcode.react でQRコードをSVG描画
- クリップボードコピー機能（フォールバック付き）
- Web Share API対応端末でネイティブ共有メニューを利用可能
- 名刺データがない場合のエラー表示・作成画面への誘導
- ぶつけ交換画面への導線を配置

## Test plan
- [x] 名刺データなし → エラーメッセージ表示
- [x] 名刺データあり → QRコード・共有URL表示
- [x] 共有URLに名刺データが含まれる
- [x] コピーボタンでクリップボードにコピー
- [x] 交換画面への導線が表示される
- [x] 全テスト合格（52/52 pass）

Closes #10