### PR TITLE
feat: 共有URLからの名刺受信・作成誘導画面 (#11)

### DIFF
--- a/src/pages/ReceivePage.test.tsx
+++ b/src/pages/ReceivePage.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ReceivePage } from "./ReceivePage";
+import { encode } from "../utils/meishiEncoder";
+import type { MeishiData } from "../types";
+
+const mockMeishi: MeishiData = {
+  id: "test-id",
+  prefecture: "大阪府",
+  topics: [
+    {
+      topic: { id: "1", text: "たこ焼きは主食", category: "食文化" },
+      agrees: true,
+    },
+    {
+      topic: { id: "2", text: "エスカレーターは右に立つ", category: "習慣" },
+      agrees: false,
+    },
+  ],
+  createdAt: "2026-03-14T00:00:00.000Z",
+};
+
+const renderWithParams = (search: string) =>
+  render(
+    <MemoryRouter initialEntries={[`/receive${search}`]}>
+      <ReceivePage />
+    </MemoryRouter>
+  );
+
+describe("ReceivePage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("クエリパラメータがない場合はエラーメッセージを表示する", () => {
+    renderWithParams("");
+    expect(screen.getByText("エラー")).toBeDefined();
+    expect(screen.getByText("共有データが見つかりません")).toBeDefined();
+  });
+
+  it("不正なデータの場合はエラーメッセージを表示する", () => {
+    renderWithParams("?d=invalid-data!!!");
+    expect(screen.getByText("エラー")).toBeDefined();
+    expect(
+      screen.getByText("名刺データの読み取りに失敗しました")
+    ).toBeDefined();
+  });
+
+  it("正しいデータの場合は送信者の名刺を表示する", () => {
+    const encoded = encode(mockMeishi);
+    renderWithParams(`?d=${encoded}`);
+    expect(screen.getByText("名刺が届きました！")).toBeDefined();
+    expect(screen.getByText("大阪府")).toBeDefined();
+    expect(screen.getByText("たこ焼きは主食")).toBeDefined();
+    expect(screen.getByText("エスカレーターは右に立つ")).toBeDefined();
+  });
+
+  it("立場（同意/反対）が正しく表示される", () => {
+    const encoded = encode(mockMeishi);
+    renderWithParams(`?d=${encoded}`);
+    expect(screen.getByText("同意")).toBeDefined();
+    expect(screen.getByText("反対")).toBeDefined();
+  });
+
+  it("カテゴリが表示される", () => {
+    const encoded = encode(mockMeishi);
+    renderWithParams(`?d=${encoded}`);
+    expect(screen.getByText("食文化")).toBeDefined();
+    expect(screen.getByText("習慣")).toBeDefined();
+  });
+
+  it("「自分の名刺も作る」ボタンが表示される", () => {
+    const encoded = encode(mockMeishi);
+    renderWithParams(`?d=${encoded}`);
+    expect(screen.getByText("自分の名刺も作る")).toBeDefined();
+  });
+
+  it("エラー時に「自分の名刺を作る」ボタンが表示される", () => {
+    renderWithParams("");
+    expect(screen.getByText("自分の名刺を作る")).toBeDefined();
+  });
+});

--- a/src/pages/ReceivePage.tsx
+++ b/src/pages/ReceivePage.tsx
@@ -1,3 +1,95 @@
+import { useMemo } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import { decode } from "../utils/meishiEncoder";
+import type { MeishiData } from "../types";
+
 export function ReceivePage() {
-  return <div>名刺受信</div>;
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const { meishi, error } = useMemo(() => {
+    const encoded = searchParams.get("d");
+    if (!encoded) {
+      return { meishi: null, error: "共有データが見つかりません" };
+    }
+    try {
+      const decoded = decode(encoded);
+      return { meishi: decoded as MeishiData, error: null };
+    } catch {
+      return { meishi: null, error: "名刺データの読み取りに失敗しました" };
+    }
+  }, [searchParams]);
+
+  if (error || !meishi) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] px-4">
+        <p className="text-red-500 text-lg font-bold mb-2">エラー</p>
+        <p className="text-gray-600 mb-6">{error}</p>
+        <button
+          onClick={() => navigate("/")}
+          className="px-6 py-3 bg-blue-500 text-white rounded-xl font-bold"
+        >
+          自分の名刺を作る
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center px-4 py-8 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-2">名刺が届きました！</h1>
+      <p className="text-gray-500 text-sm mb-8">
+        {meishi.prefecture}の人から名刺が届いたよ
+      </p>
+
+      {/* 受信した名刺カード */}
+      <div className="w-full bg-white rounded-2xl shadow-lg p-6 mb-8">
+        <div className="text-center mb-4">
+          <span className="inline-block px-4 py-1 bg-blue-100 text-blue-700 rounded-full text-sm font-bold">
+            {meishi.prefecture}
+          </span>
+        </div>
+
+        <ul className="space-y-3">
+          {meishi.topics.map((item) => (
+            <li
+              key={item.topic.id}
+              className="flex items-center justify-between p-3 bg-gray-50 rounded-xl"
+            >
+              <div className="flex-1">
+                <p className="text-xs text-gray-400 mb-1">
+                  {item.topic.category}
+                </p>
+                <p className="text-sm font-medium text-gray-800">
+                  {item.topic.text}
+                </p>
+              </div>
+              <span
+                className={`ml-3 px-3 py-1 rounded-full text-xs font-bold ${
+                  item.agrees
+                    ? "bg-green-100 text-green-700"
+                    : "bg-red-100 text-red-700"
+                }`}
+              >
+                {item.agrees ? "同意" : "反対"}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* 自分の名刺作成への誘導 */}
+      <button
+        onClick={() =>
+          navigate("/", { state: { partnerMeishi: meishi } })
+        }
+        className="w-full py-4 bg-blue-500 hover:bg-blue-600 text-white rounded-xl font-bold text-lg transition-colors mb-4"
+      >
+        自分の名刺も作る
+      </button>
+      <p className="text-gray-400 text-xs text-center">
+        名刺を作ると、2人の名刺を比較できるよ！
+      </p>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- 共有URLから名刺データをデコードし送信者の名刺を表示する `ReceivePage` を実装
- 出身地・各ネタ・立場（同意/反対）をカード形式で表示
- 不正なURL/データの場合はエラーメッセージを表示
- 「自分の名刺も作る」ボタンで名刺作成フローへ誘導（partnerMeishiをstateで渡す）

## Test plan
- [x] クエリパラメータなし → エラー表示
- [x] 不正データ → エラー表示
- [x] 正しいデータ → 送信者の名刺表示
- [x] 立場（同意/反対）の正確な表示
- [x] カテゴリ表示
- [x] 「自分の名刺も作る」ボタン表示
- [x] エラー時の作成導線表示
- [x] 全テスト合格（59/59 pass）

Closes #11