### PR TITLE
feat: 比較表示画面（一致/不一致ハイライト） (#12)

### DIFF
--- a/src/pages/ComparisonPage.test.tsx
+++ b/src/pages/ComparisonPage.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ComparisonPage } from "./ComparisonPage";
+import type { MeishiData } from "../types";
+
+const createMeishi = (
+  prefecture: string,
+  stances: { text: string; category: string; agrees: boolean }[]
+): MeishiData => ({
+  id: `test-${prefecture}`,
+  prefecture,
+  topics: stances.map((s, i) => ({
+    topic: { id: String(i + 1), text: s.text, category: s.category },
+    agrees: s.agrees,
+  })),
+  createdAt: "2026-03-14T00:00:00.000Z",
+});
+
+const myMeishi = createMeishi("大阪府", [
+  { text: "たこ焼きは主食", category: "食文化", agrees: true },
+  { text: "エスカレーターは右に立つ", category: "習慣", agrees: true },
+  { text: "〜やねん は標準語", category: "方言", agrees: false },
+]);
+
+const partnerMeishi = createMeishi("東京都", [
+  { text: "たこ焼きは主食", category: "食文化", agrees: true },
+  { text: "エスカレーターは右に立つ", category: "習慣", agrees: false },
+  { text: "〜やねん は標準語", category: "方言", agrees: false },
+]);
+
+const renderWithState = (state?: Record<string, unknown>) =>
+  render(
+    <MemoryRouter initialEntries={[{ pathname: "/comparison", state }]}>
+      <ComparisonPage />
+    </MemoryRouter>
+  );
+
+describe("ComparisonPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("比較データがない場合はエラーメッセージを表示する", () => {
+    renderWithState();
+    expect(screen.getByText("比較データがありません")).toBeDefined();
+    expect(screen.getByText("名刺を作る")).toBeDefined();
+  });
+
+  it("サマリーに一致数・不一致数が表示される", () => {
+    renderWithState({ myMeishi, partnerMeishi });
+    // サマリー部分のみ検証（カード内にも「一致」「不一致」が出るためDOM検索）
+    const summary = document.querySelector(".flex.gap-4.mb-8");
+    expect(summary).not.toBeNull();
+    expect(summary!.textContent).toContain("2");
+    expect(summary!.textContent).toContain("1");
+    expect(summary!.textContent).toContain("一致");
+    expect(summary!.textContent).toContain("不一致");
+  });
+
+  it("出身地が両方表示される", () => {
+    renderWithState({ myMeishi, partnerMeishi });
+    expect(screen.getByText("大阪府")).toBeDefined();
+    expect(screen.getByText("東京都")).toBeDefined();
+  });
+
+  it("各ネタが表示される", () => {
+    renderWithState({ myMeishi, partnerMeishi });
+    expect(screen.getByText("たこ焼きは主食")).toBeDefined();
+    expect(screen.getByText("エスカレーターは右に立つ")).toBeDefined();
+    expect(screen.getByText("〜やねん は標準語")).toBeDefined();
+  });
+
+  it("一致/不一致のハイライトが正しい", () => {
+    renderWithState({ myMeishi, partnerMeishi });
+    const cards = document.querySelectorAll(".border-green-300, .border-red-300");
+    const greenCards = document.querySelectorAll(".border-green-300");
+    const redCards = document.querySelectorAll(".border-red-300");
+    expect(cards.length).toBe(3);
+    expect(greenCards.length).toBe(2);
+    expect(redCards.length).toBe(1);
+  });
+
+  it("会話を促すメッセージが表示される", () => {
+    renderWithState({ myMeishi, partnerMeishi });
+    const messages = document.querySelectorAll('[data-testid="match-message"]');
+    expect(messages.length).toBe(3);
+    // 各メッセージが空でないことを確認
+    messages.forEach((msg) => {
+      expect(msg.textContent?.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("「もう一度名刺を作る」ボタンが表示される", () => {
+    renderWithState({ myMeishi, partnerMeishi });
+    expect(screen.getByText("もう一度名刺を作る")).toBeDefined();
+  });
+});

--- a/src/pages/ComparisonPage.tsx
+++ b/src/pages/ComparisonPage.tsx
@@ -1,3 +1,172 @@
+import { useMemo } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { compareMeishi } from "../utils/comparison";
+import type { MeishiData, TopicMatch } from "../types";
+
+const MATCH_MESSAGES = [
+  "お前もそうなん！",
+  "わかるわ〜！",
+  "それな！",
+  "仲間やん！",
+  "せやせや！",
+] as const;
+
+const MISMATCH_MESSAGES = [
+  "え、マジで！？",
+  "嘘やろ！？",
+  "そっち派なん！？",
+  "信じられへん！",
+  "ここ議論やな！",
+] as const;
+
+const pickMessage = (messages: ReadonlyArray<string>, index: number): string =>
+  messages[index % messages.length];
+
+function TopicMatchCard({
+  match,
+  index,
+}: {
+  readonly match: TopicMatch;
+  readonly index: number;
+}) {
+  const message = match.isMatch
+    ? pickMessage(MATCH_MESSAGES, index)
+    : pickMessage(MISMATCH_MESSAGES, index);
+
+  return (
+    <div
+      className={`p-4 rounded-xl border-2 ${
+        match.isMatch
+          ? "border-green-300 bg-green-50"
+          : "border-red-300 bg-red-50"
+      }`}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs text-gray-400">{match.category}</span>
+        <span
+          className={`text-xs font-bold px-2 py-0.5 rounded-full ${
+            match.isMatch
+              ? "bg-green-200 text-green-800"
+              : "bg-red-200 text-red-800"
+          }`}
+        >
+          {match.isMatch ? "一致" : "不一致"}
+        </span>
+      </div>
+
+      <p className="text-sm font-medium text-gray-800 mb-3">
+        {match.topicText}
+      </p>
+
+      <div className="flex gap-3 mb-2">
+        <div className="flex-1 text-center">
+          <p className="text-xs text-gray-400 mb-1">自分</p>
+          <span
+            className={`inline-block px-3 py-1 rounded-full text-xs font-bold ${
+              match.myStance
+                ? "bg-green-100 text-green-700"
+                : "bg-red-100 text-red-700"
+            }`}
+          >
+            {match.myStance ? "同意" : "反対"}
+          </span>
+        </div>
+        <div className="flex-1 text-center">
+          <p className="text-xs text-gray-400 mb-1">相手</p>
+          <span
+            className={`inline-block px-3 py-1 rounded-full text-xs font-bold ${
+              match.partnerStance
+                ? "bg-green-100 text-green-700"
+                : "bg-red-100 text-red-700"
+            }`}
+          >
+            {match.partnerStance ? "同意" : "反対"}
+          </span>
+        </div>
+      </div>
+
+      <p className="text-center text-sm font-bold mt-2" data-testid="match-message">
+        {message}
+      </p>
+    </div>
+  );
+}
+
 export function ComparisonPage() {
-  return <div>比較表示</div>;
+  const location = useLocation();
+  const navigate = useNavigate();
+  const myMeishi = location.state?.myMeishi as MeishiData | undefined;
+  const partnerMeishi = location.state?.partnerMeishi as
+    | MeishiData
+    | undefined;
+
+  const result = useMemo(() => {
+    if (!myMeishi || !partnerMeishi) return null;
+    return compareMeishi(myMeishi, partnerMeishi);
+  }, [myMeishi, partnerMeishi]);
+
+  if (!result) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] px-4">
+        <p className="text-gray-600 text-lg mb-4">比較データがありません</p>
+        <button
+          onClick={() => navigate("/")}
+          className="px-6 py-3 bg-blue-500 text-white rounded-xl font-bold"
+        >
+          名刺を作る
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center px-4 py-8 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-2">比較結果</h1>
+
+      {/* サマリー */}
+      <div className="flex gap-4 mb-8">
+        <div className="flex items-center gap-2 px-4 py-2 bg-green-100 rounded-xl">
+          <span className="text-green-700 font-bold text-xl">
+            {result.matchCount}
+          </span>
+          <span className="text-green-600 text-sm">一致</span>
+        </div>
+        <div className="flex items-center gap-2 px-4 py-2 bg-red-100 rounded-xl">
+          <span className="text-red-700 font-bold text-xl">
+            {result.mismatchCount}
+          </span>
+          <span className="text-red-600 text-sm">不一致</span>
+        </div>
+      </div>
+
+      {/* 出身地表示 */}
+      <div className="flex gap-4 mb-6 w-full">
+        <div className="flex-1 text-center">
+          <span className="inline-block px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm font-bold">
+            {result.myMeishi.prefecture}
+          </span>
+        </div>
+        <div className="flex-1 text-center">
+          <span className="inline-block px-3 py-1 bg-purple-100 text-purple-700 rounded-full text-sm font-bold">
+            {result.partnerMeishi.prefecture}
+          </span>
+        </div>
+      </div>
+
+      {/* 各ネタの比較 */}
+      <div className="w-full space-y-4 mb-8">
+        {result.matches.map((match, index) => (
+          <TopicMatchCard key={match.topicText} match={match} index={index} />
+        ))}
+      </div>
+
+      {/* もう一度 */}
+      <button
+        onClick={() => navigate("/")}
+        className="w-full py-3 border-2 border-blue-500 text-blue-500 rounded-xl font-bold hover:bg-blue-50 transition-colors"
+      >
+        もう一度名刺を作る
+      </button>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- 2人の名刺を比較表示する `ComparisonPage` を実装
- 一致項目は緑、不一致項目は赤でハイライト表示
- 一致数/不一致数のサマリーを画面上部に表示
- 各ネタに会話を促すメッセージを添付（「お前もそうなん！」「え、マジで！？」等）
- 自分・相手の出身地と各立場（同意/反対）を明示
- `compareMeishi` ユーティリティを利用

## Test plan
- [x] 比較データなし → エラー表示
- [x] サマリーに一致数・不一致数が表示
- [x] 出身地が両方表示
- [x] 各ネタが表示
- [x] 一致/不一致の色分けハイライトが正しい
- [x] 会話を促すメッセージが表示
- [x] 「もう一度名刺を作る」ボタン表示
- [x] 全テスト合格（66/66 pass）

Closes #12