### PR TITLE
Implement meishi preview screen

### DIFF
--- a/src/hooks/useExchangeSocket.test.ts
+++ b/src/hooks/useExchangeSocket.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useExchangeSocket } from "./useExchangeSocket";
 import type { MeishiData } from "../types";

--- a/src/pages/MeishiPreviewPage.test.tsx
+++ b/src/pages/MeishiPreviewPage.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { MeishiPreviewPage } from "./MeishiPreviewPage";
+
+const renderPreviewPage = () =>
+  render(
+    <MemoryRouter initialEntries={["/preview"]}>
+      <Routes>
+        <Route path="/preview" element={<MeishiPreviewPage />} />
+        <Route path="/topics" element={<div>topics page</div>} />
+        <Route path="/share" element={<div>share page</div>} />
+        <Route path="/" element={<div>home page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe("MeishiPreviewPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
+    vi.spyOn(Date.prototype, "toISOString").mockReturnValue("2026-03-14T00:00:00.000Z");
+  });
+
+  it("保存済みデータがない場合は案内を表示する", () => {
+    renderPreviewPage();
+
+    expect(screen.getByText("名刺データがありません")).toBeDefined();
+    expect(screen.getByText("最初からつくる")).toBeDefined();
+  });
+
+  it("保存済みデータがある場合は名刺プレビューを表示する", () => {
+    window.sessionStorage.setItem("jimoto:selectedPrefecture", "大阪府");
+    window.sessionStorage.setItem(
+      "jimoto:selectedTopics",
+      JSON.stringify([
+        {
+          topic: { id: "1", text: "たこ焼きは主食", category: "食文化" },
+          agrees: true,
+        },
+        {
+          topic: { id: "2", text: "エスカレーターは右に立つ", category: "習慣" },
+          agrees: false,
+        },
+      ])
+    );
+
+    renderPreviewPage();
+
+    expect(screen.getByText("大阪府")).toBeDefined();
+    expect(screen.getByText("たこ焼きは主食")).toBeDefined();
+    expect(screen.getAllByText(/派/)).toHaveLength(2);
+    expect(screen.getByText("この名刺を共有する")).toBeDefined();
+  });
+
+  it("共有ボタンで共有画面へ進める", () => {
+    window.sessionStorage.setItem("jimoto:selectedPrefecture", "大阪府");
+    window.sessionStorage.setItem(
+      "jimoto:selectedTopics",
+      JSON.stringify([
+        {
+          topic: { id: "1", text: "たこ焼きは主食", category: "食文化" },
+          agrees: true,
+        },
+      ])
+    );
+
+    renderPreviewPage();
+    fireEvent.click(screen.getByText("この名刺を共有する"));
+
+    expect(screen.getByText("share page")).toBeDefined();
+  });
+});

--- a/src/pages/MeishiPreviewPage.tsx
+++ b/src/pages/MeishiPreviewPage.tsx
@@ -1,3 +1,134 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import type { MeishiData } from "../types";
+import { loadSelectedPrefecture, loadSelectedTopics } from "../utils/appStorage";
+
+function createMeishiId() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `meishi-${Date.now()}`;
+}
+
 export function MeishiPreviewPage() {
-  return <div>名刺プレビュー</div>;
+  const navigate = useNavigate();
+  const prefecture = loadSelectedPrefecture();
+  const topics = loadSelectedTopics();
+
+  const meishi = useMemo<MeishiData | null>(() => {
+    if (!prefecture || topics.length === 0) {
+      return null;
+    }
+
+    return {
+      id: createMeishiId(),
+      prefecture,
+      topics,
+      createdAt: new Date().toISOString(),
+    };
+  }, [prefecture, topics]);
+
+  if (!meishi) {
+    return (
+      <div className="mx-auto flex min-h-[70vh] max-w-md flex-col items-center justify-center px-4 text-center">
+        <div className="rounded-[32px] border border-orange-100 bg-white px-6 py-8 shadow-sm">
+          <p className="text-sm font-semibold tracking-[0.2em] text-orange-500">PREVIEW</p>
+          <h2 className="mt-3 text-2xl font-bold text-gray-900">名刺データがありません</h2>
+          <p className="mt-3 text-sm leading-6 text-gray-500">
+            先に出身地を選んで、ネタの立場を決めてください。
+          </p>
+          <div className="mt-6 flex flex-col gap-3">
+            <button
+              type="button"
+              onClick={() => navigate("/")}
+              className="rounded-full bg-linear-to-r from-orange-500 to-pink-500 px-5 py-3 font-bold text-white"
+            >
+              最初からつくる
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate("/topics")}
+              className="rounded-full border border-gray-200 px-5 py-3 font-semibold text-gray-700"
+            >
+              ネタ選択に戻る
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col gap-5 pb-8">
+      <section className="rounded-[28px] bg-linear-to-br from-slate-950 via-slate-900 to-orange-950 px-5 py-6 text-white shadow-xl">
+        <p className="text-xs font-semibold tracking-[0.24em] text-orange-300">JIMOTO MEISHI</p>
+        <div className="mt-4 flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-3xl font-bold tracking-tight">{meishi.prefecture}</h2>
+            <p className="mt-2 text-sm leading-6 text-white/70">
+              地元では普通。でも外に出ると会話になる、わたしの論点カード。
+            </p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/10 px-3 py-2 text-right backdrop-blur-sm">
+            <p className="text-[10px] tracking-[0.18em] text-white/50">TOPICS</p>
+            <p className="text-2xl font-bold">{meishi.topics.length}</p>
+          </div>
+        </div>
+
+        <div className="mt-6 space-y-3">
+          {meishi.topics.map(({ topic, agrees }, index) => (
+            <article
+              key={topic.id}
+              className="rounded-2xl border border-white/10 bg-white/8 px-4 py-4 backdrop-blur-sm"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex h-7 min-w-7 items-center justify-center rounded-full bg-white/12 px-2 text-xs font-bold">
+                    {index + 1}
+                  </span>
+                  <span className="rounded-full bg-orange-400/15 px-2.5 py-1 text-[11px] font-semibold text-orange-200">
+                    {topic.category}
+                  </span>
+                </div>
+                <span
+                  className={`rounded-full px-3 py-1 text-xs font-bold ${
+                    agrees
+                      ? "bg-emerald-400/20 text-emerald-200"
+                      : "bg-sky-400/20 text-sky-200"
+                  }`}
+                >
+                  {agrees ? "わかる派" : "違う派"}
+                </span>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-white/92">{topic.text}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-[28px] border border-gray-100 bg-white p-5 shadow-sm">
+        <h3 className="text-lg font-bold text-gray-900">この名刺でよければ共有へ</h3>
+        <p className="mt-2 text-sm leading-6 text-gray-500">
+          QR表示とURL共有は次の画面で行います。気になるなら一度ネタ選択に戻って調整できます。
+        </p>
+        <div className="mt-5 flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={() => navigate("/share", { state: { meishi } })}
+            className="rounded-full bg-linear-to-r from-orange-500 to-pink-500 px-5 py-4 text-lg font-bold text-white shadow-lg transition hover:scale-[1.01] active:scale-95"
+          >
+            この名刺を共有する
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate("/topics")}
+            className="rounded-full border border-gray-200 px-5 py-4 font-semibold text-gray-700 transition hover:bg-gray-50"
+          >
+            ネタ選択に戻る
+          </button>
+        </div>
+      </section>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- implement the meishi preview screen for issue #9
- build MeishiData from saved prefecture and selected topics, then pass it to the share page
- add preview page tests and fix a small existing test type issue

## Testing
- npm run build
- npx vitest run src/pages/MeishiPreviewPage.test.tsx
- npm test *(server tests are blocked in this sandbox by listen EPERM)*