### PR TITLE
feat: 全画面フロー結合・ルーティング最終調整 (#18)

### DIFF
--- a/src/pages/ExchangePage.tsx
+++ b/src/pages/ExchangePage.tsx
@@ -1,3 +1,13 @@
+import { useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+
 export function ExchangePage() {
-  return <div>ぶつけ交換</div>;
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    navigate("/share", { state: location.state, replace: true });
+  }, [navigate, location.state]);
+
+  return null;
 }

--- a/src/pages/MeishiPreviewPage.tsx
+++ b/src/pages/MeishiPreviewPage.tsx
@@ -1,7 +1,12 @@
 import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import type { MeishiData } from "../types";
-import { loadSelectedPrefecture, loadSelectedTopics } from "../utils/appStorage";
+import {
+  loadSelectedPrefecture,
+  loadSelectedTopics,
+  loadPartnerMeishi,
+  clearPartnerMeishi,
+} from "../utils/appStorage";
 
 function createMeishiId() {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
@@ -15,6 +20,7 @@ export function MeishiPreviewPage() {
   const navigate = useNavigate();
   const prefecture = loadSelectedPrefecture();
   const topics = loadSelectedTopics();
+  const partnerMeishi = loadPartnerMeishi();
 
   const meishi = useMemo<MeishiData | null>(() => {
     if (!prefecture || topics.length === 0) {
@@ -113,13 +119,28 @@ export function MeishiPreviewPage() {
           QR表示とURL共有は次の画面で行います。気になるなら一度ネタ選択に戻って調整できます。
         </p>
         <div className="mt-5 flex flex-col gap-3">
-          <button
-            type="button"
-            onClick={() => navigate("/share", { state: { meishi } })}
-            className="rounded-full bg-linear-to-r from-orange-500 to-pink-500 px-5 py-4 text-lg font-bold text-white shadow-lg transition hover:scale-[1.01] active:scale-95"
-          >
-            この名刺を共有する
-          </button>
+          {partnerMeishi ? (
+            <button
+              type="button"
+              onClick={() => {
+                clearPartnerMeishi();
+                navigate("/comparison", {
+                  state: { myMeishi: meishi, partnerMeishi },
+                });
+              }}
+              className="rounded-full bg-linear-to-r from-emerald-500 to-teal-500 px-5 py-4 text-lg font-bold text-white shadow-lg transition hover:scale-[1.01] active:scale-95"
+            >
+              名刺を比較する
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => navigate("/share", { state: { meishi } })}
+              className="rounded-full bg-linear-to-r from-orange-500 to-pink-500 px-5 py-4 text-lg font-bold text-white shadow-lg transition hover:scale-[1.01] active:scale-95"
+            >
+              この名刺を共有する
+            </button>
+          )}
           <button
             type="button"
             onClick={() => navigate("/topics")}

--- a/src/pages/ReceivePage.tsx
+++ b/src/pages/ReceivePage.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { decode } from "../utils/meishiEncoder";
+import { savePartnerMeishi } from "../utils/appStorage";
 import type { MeishiData } from "../types";
 
 export function ReceivePage() {
@@ -80,9 +81,10 @@ export function ReceivePage() {
 
       {/* 自分の名刺作成への誘導 */}
       <button
-        onClick={() =>
-          navigate("/", { state: { partnerMeishi: meishi } })
-        }
+        onClick={() => {
+          savePartnerMeishi(meishi);
+          navigate("/");
+        }}
         className="w-full py-4 bg-blue-500 hover:bg-blue-600 text-white rounded-xl font-bold text-lg transition-colors mb-4"
       >
         自分の名刺も作る

--- a/src/pages/SharePage.test.tsx
+++ b/src/pages/SharePage.test.tsx
@@ -69,8 +69,8 @@ describe("SharePage", () => {
     );
   });
 
-  it("交換画面への導線が表示される", () => {
+  it("トップに戻るボタンが表示される", () => {
     renderWithRouter({ meishi: mockMeishi });
-    expect(screen.getByText("ぶつけて交換する")).toBeDefined();
+    expect(screen.getByText("トップに戻る")).toBeDefined();
   });
 });

--- a/src/pages/SharePage.tsx
+++ b/src/pages/SharePage.tsx
@@ -103,12 +103,12 @@ export function SharePage() {
         </button>
       )}
 
-      {/* 交換画面への導線 */}
+      {/* トップに戻る */}
       <button
-        onClick={() => navigate("/exchange", { state: { meishi } })}
-        className="w-full py-3 border-2 border-blue-500 text-blue-500 rounded-xl font-bold hover:bg-blue-50 transition-colors"
+        onClick={() => navigate("/")}
+        className="w-full py-3 border-2 border-gray-300 text-gray-600 rounded-xl font-bold hover:bg-gray-50 transition-colors"
       >
-        ぶつけて交換する
+        トップに戻る
       </button>
     </div>
   );

--- a/src/utils/appStorage.ts
+++ b/src/utils/appStorage.ts
@@ -1,7 +1,8 @@
-import type { TopicWithStance } from "../types";
+import type { MeishiData, TopicWithStance } from "../types";
 
 const PREFECTURE_KEY = "jimoto:selectedPrefecture";
 const TOPICS_KEY = "jimoto:selectedTopics";
+const PARTNER_MEISHI_KEY = "jimoto:partnerMeishi";
 
 function isBrowser() {
   return typeof window !== "undefined";
@@ -47,4 +48,38 @@ export function loadSelectedTopics(): ReadonlyArray<TopicWithStance> {
   } catch {
     return [];
   }
+}
+
+export function savePartnerMeishi(meishi: MeishiData) {
+  if (!isBrowser()) {
+    return;
+  }
+
+  window.sessionStorage.setItem(PARTNER_MEISHI_KEY, JSON.stringify(meishi));
+}
+
+export function loadPartnerMeishi(): MeishiData | null {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  const raw = window.sessionStorage.getItem(PARTNER_MEISHI_KEY);
+
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as MeishiData;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPartnerMeishi() {
+  if (!isBrowser()) {
+    return;
+  }
+
+  window.sessionStorage.removeItem(PARTNER_MEISHI_KEY);
 }


### PR DESCRIPTION
## Summary
- partnerMeishiをsessionStorageで永続化し、URL受信→名刺作成→比較のフローを一連で接続
- MeishiPreviewPageにpartnerMeishi存在時の「名刺を比較する」導線を追加
- ぶつけ交換（7.x/8.x）スキップに伴い、SharePage・ExchangePageを整理

## 変更ファイル
| ファイル | 内容 |
|---------|------|
| `appStorage.ts` | `savePartnerMeishi` / `loadPartnerMeishi` / `clearPartnerMeishi` 追加 |
| `ReceivePage.tsx` | partnerMeishiをsessionStorageに保存（location.state依存を解消）|
| `MeishiPreviewPage.tsx` | partnerMeishiがあれば「名刺を比較する」ボタン表示 |
| `SharePage.tsx` | 「ぶつけて交換する」→「トップに戻る」に変更 |
| `ExchangePage.tsx` | SharePageへリダイレクト |
| `SharePage.test.tsx` | テストを変更に合わせて更新 |

## Test plan
- [x] 全テスト通過（69/69）
- [ ] 通常フロー動作確認: 名刺作成 → プレビュー → 共有
- [ ] URL受信フロー動作確認: /receive?d=... → 名刺作成 → プレビュー → 比較
- [ ] /exchange アクセス時にSharePageへリダイレクトされること

Closes #18