### PR TITLE
feat: モバイルUI最終調整・レスポンシブ対応 (#19)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>jimoto-meishi-tmp</title>
   </head>
   <body>

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -2,7 +2,7 @@ import { Outlet } from "react-router-dom";
 
 export function Layout() {
   return (
-    <div className="min-h-svh flex flex-col bg-white">
+    <div className="min-h-svh flex flex-col bg-white" style={{ paddingTop: "env(safe-area-inset-top)" }}>
       <header className="bg-gradient-to-r from-orange-500 to-pink-500 text-white px-4 py-3">
         <h1 className="text-lg font-bold text-center">じもと名刺</h1>
       </header>

--- a/src/pages/ComparisonPage.tsx
+++ b/src/pages/ComparisonPage.tsx
@@ -107,11 +107,11 @@ export function ComparisonPage() {
 
   if (!result) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] px-4">
+      <div className="flex flex-col items-center justify-center min-h-[40vh] px-4">
         <p className="text-gray-600 text-lg mb-4">比較データがありません</p>
         <button
           onClick={() => navigate("/")}
-          className="px-6 py-3 bg-blue-500 text-white rounded-xl font-bold"
+          className="px-6 py-3 min-h-[44px] bg-blue-500 text-white rounded-xl font-bold"
         >
           名刺を作る
         </button>

--- a/src/pages/MeishiPreviewPage.tsx
+++ b/src/pages/MeishiPreviewPage.tsx
@@ -37,7 +37,7 @@ export function MeishiPreviewPage() {
 
   if (!meishi) {
     return (
-      <div className="mx-auto flex min-h-[70vh] max-w-md flex-col items-center justify-center px-4 text-center">
+      <div className="mx-auto flex min-h-[40vh] max-w-md flex-col items-center justify-center px-4 text-center">
         <div className="rounded-[32px] border border-orange-100 bg-white px-6 py-8 shadow-sm">
           <p className="text-sm font-semibold tracking-[0.2em] text-orange-500">PREVIEW</p>
           <h2 className="mt-3 text-2xl font-bold text-gray-900">名刺データがありません</h2>

--- a/src/pages/PrefectureSelectPage.tsx
+++ b/src/pages/PrefectureSelectPage.tsx
@@ -66,7 +66,7 @@ export function PrefectureSelectPage() {
                     key={pref}
                     onClick={() => setSelectedPrefecture(pref)}
                     className={`
-                      py-2 px-1 text-sm rounded-lg transition-all duration-200 ease-in-out font-medium
+                      min-h-[44px] py-2.5 px-1 text-sm rounded-lg transition-all duration-200 ease-in-out font-medium
                       ${
                         isSelected
                           ? "bg-gradient-to-r from-orange-500 to-pink-500 text-white shadow-md transform scale-105"
@@ -84,7 +84,7 @@ export function PrefectureSelectPage() {
       </div>
 
       {/* フローティングアクションボタンエリア */}
-      <div className="fixed bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-white via-white to-transparent pb-6">
+      <div className="fixed bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-white via-white to-transparent" style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 1rem)" }}>
         <div className="max-w-md mx-auto">
           <button
             onClick={handleNext}

--- a/src/pages/ReceivePage.tsx
+++ b/src/pages/ReceivePage.tsx
@@ -23,12 +23,12 @@ export function ReceivePage() {
 
   if (error || !meishi) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] px-4">
+      <div className="flex flex-col items-center justify-center min-h-[40vh] px-4">
         <p className="text-red-500 text-lg font-bold mb-2">エラー</p>
         <p className="text-gray-600 mb-6">{error}</p>
         <button
           onClick={() => navigate("/")}
-          className="px-6 py-3 bg-blue-500 text-white rounded-xl font-bold"
+          className="px-6 py-3 min-h-[44px] bg-blue-500 text-white rounded-xl font-bold"
         >
           自分の名刺を作る
         </button>

--- a/src/pages/SharePage.tsx
+++ b/src/pages/SharePage.tsx
@@ -46,11 +46,11 @@ export function SharePage() {
 
   if (!meishi) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] px-4">
+      <div className="flex flex-col items-center justify-center min-h-[40vh] px-4">
         <p className="text-gray-600 text-lg mb-4">名刺データがありません</p>
         <button
           onClick={() => navigate("/")}
-          className="px-6 py-3 bg-blue-500 text-white rounded-xl font-bold"
+          className="px-6 py-3 min-h-[44px] bg-blue-500 text-white rounded-xl font-bold"
         >
           名刺を作る
         </button>

--- a/src/pages/TopicGenerationPage.tsx
+++ b/src/pages/TopicGenerationPage.tsx
@@ -154,7 +154,7 @@ export function TopicGenerationPage() {
             type="button"
             onClick={() => void handleRegenerate()}
             disabled={isLoading}
-            className="rounded-full border border-white/30 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
+            className="rounded-full border border-white/30 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60 min-h-[44px]"
           >
             別のネタにする
           </button>
@@ -256,7 +256,7 @@ export function TopicGenerationPage() {
           })}
       </section>
 
-      <div className="fixed bottom-0 left-0 right-0 bg-gradient-to-t from-white via-white to-transparent px-4 pb-6 pt-4">
+      <div className="fixed bottom-0 left-0 right-0 bg-gradient-to-t from-white via-white to-transparent px-4 pt-4" style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 1rem)" }}>
         <div className="mx-auto max-w-md">
           <button
             type="button"


### PR DESCRIPTION
## Summary
- viewport-fit=coverでiOSノッチ・ホームインジケーター対応
- 全ページのタッチターゲットを44px以上に統一
- 固定フッター（都道府県選択・ネタ生成画面）にsafe-area-inset-bottom適用
- 横向き時のレイアウトオーバーフロー防止（min-height 60vh→40vh）

## Test plan
- [x] 全テスト通過（69/69）
- [ ] iPhone Safari でノッチ周辺のレイアウト確認
- [ ] Android Chrome で全画面タッチ操作確認
- [ ] 横向き表示でレイアウト崩れがないこと

Closes #19