### PR TITLE
feat: E2Eテスト追加 (#20)

### DIFF
--- a/e2e/comparison.spec.ts
+++ b/e2e/comparison.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from "@playwright/test";
+import type { MeishiData } from "../src/types";
+
+const partnerMeishi: MeishiData = {
+  id: "e2e-partner",
+  prefecture: "東京都",
+  topics: [
+    {
+      topic: { id: "1", text: "たこ焼きは主食", category: "食文化" },
+      agrees: false,
+    },
+    {
+      topic: { id: "2", text: "エスカレーターは右に立つ", category: "習慣" },
+      agrees: true,
+    },
+    {
+      topic: {
+        id: "3",
+        text: "知らん人にも話しかける",
+        category: "地元あるある",
+      },
+      agrees: false,
+    },
+  ],
+  createdAt: "2026-03-14T00:00:00.000Z",
+};
+
+function encodeMeishi(data: MeishiData): string {
+  const json = JSON.stringify(data);
+  const base64 = Buffer.from(json, "utf-8").toString("base64");
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+test.describe("比較表示", () => {
+  test("URL受信 → 名刺作成 → 比較画面で一致/不一致がハイライトされる", async ({
+    page,
+  }) => {
+    const encoded = encodeMeishi(partnerMeishi);
+
+    // 1. 受信ページでpartnerMeishiを保存
+    await page.goto(`/receive?d=${encoded}`);
+    await page.getByRole("button", { name: "自分の名刺も作る" }).click();
+
+    // 2. 名刺作成フロー
+    await expect(page).toHaveURL("/");
+    await page.getByRole("button", { name: "大阪府" }).click();
+    await page.getByRole("button", { name: /大阪府で決定/ }).click();
+
+    await expect(page.getByText("TOPIC 1")).toBeVisible({ timeout: 15_000 });
+
+    const agreeButtons = page.getByRole("button", { name: "それ、わかる" });
+    const count = await agreeButtons.count();
+    for (let i = 0; i < count; i++) {
+      await agreeButtons.nth(i).click();
+    }
+
+    await page
+      .getByRole("button", { name: "この内容で名刺をつくる" })
+      .click();
+
+    // 3. プレビューから比較へ
+    await expect(page).toHaveURL("/preview");
+    await page.getByRole("button", { name: "名刺を比較する" }).click();
+
+    // 4. 比較結果の検証
+    await expect(page).toHaveURL("/comparison");
+    await expect(page.getByText("比較結果")).toBeVisible();
+
+    // サマリーが表示される
+    await expect(page.getByText("一致").first()).toBeVisible();
+    await expect(page.getByText("不一致").first()).toBeVisible();
+
+    // 出身地が表示される
+    await expect(page.getByText("大阪府", { exact: true })).toBeVisible();
+    await expect(page.getByText("東京都", { exact: true })).toBeVisible();
+
+    // 会話メッセージが表示される
+    const messages = page.locator('[data-testid="match-message"]');
+    const messageCount = await messages.count();
+    expect(messageCount).toBeGreaterThan(0);
+
+    // 「もう一度名刺を作る」ボタンが表示される
+    await expect(
+      page.getByRole("button", { name: "もう一度名刺を作る" })
+    ).toBeVisible();
+  });
+
+  test("比較データなしでアクセスするとエラー表示", async ({ page }) => {
+    await page.goto("/comparison");
+    await expect(page.getByText("比較データがありません")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "名刺を作る" })
+    ).toBeVisible();
+  });
+});

--- a/e2e/meishi-creation.spec.ts
+++ b/e2e/meishi-creation.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("名刺作成フロー", () => {
+  test("都道府県選択 → ネタ生成 → 立場選択 → 名刺プレビュー完成", async ({
+    page,
+  }) => {
+    // 1. トップページ（都道府県選択）
+    await page.goto("/");
+    await expect(page.getByText("出身地はどこ？")).toBeVisible();
+
+    // 大阪府を選択
+    await page.getByRole("button", { name: "大阪府" }).click();
+
+    // 決定ボタン押下
+    await page.getByRole("button", { name: /大阪府で決定/ }).click();
+
+    // 2. ネタ生成画面に遷移
+    await expect(page).toHaveURL("/topics");
+    await expect(page.getByText("大阪府の")).toBeVisible();
+
+    // ネタ生成完了を待つ（ローディング → コンテンツ表示）
+    await expect(page.getByText("TOPIC 1")).toBeVisible({ timeout: 15_000 });
+
+    // 3. 全ネタで立場を選択（「それ、わかる」を全部選ぶ）
+    const agreeButtons = page.getByRole("button", { name: "それ、わかる" });
+    const count = await agreeButtons.count();
+    expect(count).toBeGreaterThanOrEqual(3);
+
+    for (let i = 0; i < count; i++) {
+      await agreeButtons.nth(i).click();
+    }
+
+    // 4. 名刺作成ボタン押下
+    await page
+      .getByRole("button", { name: "この内容で名刺をつくる" })
+      .click();
+
+    // 5. プレビュー画面に遷移
+    await expect(page).toHaveURL("/preview");
+    await expect(page.getByText("JIMOTO MEISHI")).toBeVisible();
+    await expect(page.getByText("大阪府", { exact: true })).toBeVisible();
+
+    // 共有ボタンが表示される
+    await expect(
+      page.getByRole("button", { name: "この名刺を共有する" })
+    ).toBeVisible();
+  });
+});

--- a/e2e/share-flow.spec.ts
+++ b/e2e/share-flow.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from "@playwright/test";
+import type { MeishiData } from "../src/types";
+
+const sampleMeishi: MeishiData = {
+  id: "e2e-share-test",
+  prefecture: "京都府",
+  topics: [
+    {
+      topic: { id: "1", text: "おばんざいは家庭料理", category: "食文化" },
+      agrees: true,
+    },
+    {
+      topic: { id: "2", text: "バスの乗り方が独特", category: "習慣" },
+      agrees: false,
+    },
+    {
+      topic: {
+        id: "3",
+        text: "道案内でお寺を目印にする",
+        category: "地元あるある",
+      },
+      agrees: true,
+    },
+  ],
+  createdAt: "2026-03-14T00:00:00.000Z",
+};
+
+function encodeMeishi(data: MeishiData): string {
+  const json = JSON.stringify(data);
+  const base64 = Buffer.from(json, "utf-8").toString("base64");
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+test.describe("URL/QR共有フロー", () => {
+  test("共有URL → 名刺受信 → 名刺表示", async ({ page }) => {
+    const encoded = encodeMeishi(sampleMeishi);
+
+    // 共有URLにアクセス
+    await page.goto(`/receive?d=${encoded}`);
+
+    // 受信画面が表示される
+    await expect(page.getByText("名刺が届きました！")).toBeVisible();
+    await expect(page.getByText("京都府", { exact: true })).toBeVisible();
+
+    // ネタが表示される
+    await expect(page.getByText("おばんざいは家庭料理")).toBeVisible();
+    await expect(page.getByText("バスの乗り方が独特")).toBeVisible();
+    await expect(page.getByText("道案内でお寺を目印にする")).toBeVisible();
+
+    // 「自分の名刺も作る」ボタンが表示される
+    await expect(
+      page.getByRole("button", { name: "自分の名刺も作る" })
+    ).toBeVisible();
+  });
+
+  test("共有URL → 自分の名刺作成 → 比較画面へ遷移", async ({ page }) => {
+    const encoded = encodeMeishi(sampleMeishi);
+
+    // 1. 共有URLにアクセスし「自分の名刺も作る」
+    await page.goto(`/receive?d=${encoded}`);
+    await page.getByRole("button", { name: "自分の名刺も作る" }).click();
+
+    // 2. トップページに遷移し名刺を作成
+    await expect(page).toHaveURL("/");
+    await page.getByRole("button", { name: "大阪府" }).click();
+    await page.getByRole("button", { name: /大阪府で決定/ }).click();
+
+    // 3. ネタ生成画面
+    await expect(page).toHaveURL("/topics");
+    await expect(page.getByText("TOPIC 1")).toBeVisible({ timeout: 15_000 });
+
+    // 全ネタで「それ、わかる」を選択
+    const agreeButtons = page.getByRole("button", { name: "それ、わかる" });
+    const count = await agreeButtons.count();
+    for (let i = 0; i < count; i++) {
+      await agreeButtons.nth(i).click();
+    }
+
+    await page
+      .getByRole("button", { name: "この内容で名刺をつくる" })
+      .click();
+
+    // 4. プレビュー画面で「名刺を比較する」ボタンが表示される（partnerMeishiが保存されているため）
+    await expect(page).toHaveURL("/preview");
+    await expect(
+      page.getByRole("button", { name: "名刺を比較する" })
+    ).toBeVisible();
+
+    // 5. 比較画面に遷移
+    await page.getByRole("button", { name: "名刺を比較する" }).click();
+    await expect(page).toHaveURL("/comparison");
+    await expect(page.getByText("比較結果")).toBeVisible();
+  });
+
+  test("不正な共有URLではエラーが表示される", async ({ page }) => {
+    await page.goto("/receive?d=invalid-data");
+    await expect(page.getByText("エラー")).toBeVisible();
+    await expect(
+      page.getByText("名刺データの読み取りに失敗しました")
+    ).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.2.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
@@ -786,6 +787,22 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
@@ -2815,6 +2832,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -3659,6 +3691,38 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "dev": true,
@@ -4456,6 +4520,21 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -4653,6 +4732,21 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.2.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  retries: 1,
+  use: {
+    baseURL: "http://localhost:5173",
+    headless: true,
+    viewport: { width: 390, height: 844 },
+  },
+  webServer: {
+    command: "npm run dev:client",
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/src/utils/comparison.ts
+++ b/src/utils/comparison.ts
@@ -12,8 +12,14 @@ export const compareMeishi = (
   myMeishi: MeishiData,
   partnerMeishi: MeishiData
 ): ComparisonResult => {
-  const matches: ReadonlyArray<TopicMatch> = myMeishi.topics.map(
-    (myTopic, index) => {
+  const minLength = Math.min(
+    myMeishi.topics.length,
+    partnerMeishi.topics.length
+  );
+
+  const matches: ReadonlyArray<TopicMatch> = myMeishi.topics
+    .slice(0, minLength)
+    .map((myTopic, index) => {
       const partnerTopic = partnerMeishi.topics[index];
       const isMatch = myTopic.agrees === partnerTopic.agrees;
 
@@ -24,8 +30,7 @@ export const compareMeishi = (
         partnerStance: partnerTopic.agrees,
         isMatch,
       };
-    }
-  );
+    });
 
   const matchCount = matches.filter((m) => m.isMatch).length;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    exclude: ['e2e/**', 'node_modules/**'],
+  },
 })


### PR DESCRIPTION
## Summary
- Playwright導入、主要3フローのE2Eテスト6ケースを作成
- `compareMeishi` のトピック数不一致クラッシュバグを修正（`Math.min`で安全に比較）

## テストケース
| ファイル | テスト内容 |
|---------|-----------|
| `meishi-creation.spec.ts` | 都道府県選択 → ネタ生成 → 立場選択 → プレビュー完成 |
| `share-flow.spec.ts` | 共有URL → 名刺受信表示 / URL受信 → 名刺作成 → 比較遷移 / 不正URL エラー表示 |
| `comparison.spec.ts` | URL受信 → 名刺作成 → 比較画面で一致/不一致ハイライト / データなしエラー表示 |

## Test plan
- [x] Unit tests: 69/69 通過
- [x] E2E tests: 6/6 通過
- [ ] `npm run test:e2e` で再現確認

Closes #20