### PR TITLE
feat: Renderデプロイ対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev:server": "tsx watch server/index.ts",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "start": "NODE_ENV=production tsx server/index.ts",
     "preview": "vite preview",
     "test": "vitest run",
     "test:e2e": "playwright test"
@@ -23,7 +24,8 @@
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1",
     "socket.io": "^4.8.3",
-    "socket.io-client": "^4.8.3"
+    "socket.io-client": "^4.8.3",
+    "tsx": "^4.21.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
@@ -47,7 +49,6 @@
     "postcss": "^8.5.8",
     "supertest": "^7.2.2",
     "tailwindcss": "^4.2.1",
-    "tsx": "^4.21.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.56.1",
     "vite": "^8.0.0",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: jimoto-meishi-app
+    runtime: node
+    plan: free
+    buildCommand: npm install && npm run build
+    startCommand: NODE_ENV=production npx tsx server/index.ts
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: ANTHROPIC_API_KEY
+        sync: false

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,12 +1,20 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer } from "node:http";
 import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
 import { createGenerateTopicsRouter } from "./routes/generateTopics";
+import { setupExchangeSocket } from "./socket/exchangeHandler";
 
 dotenv.config();
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const app = express();
 const PORT = process.env.PORT ?? 3001;
+const isProduction = process.env.NODE_ENV === "production";
 
 app.use(cors());
 app.use(express.json());
@@ -17,6 +25,20 @@ app.get("/api/health", (_req, res) => {
 
 app.use("/api/generate-topics", createGenerateTopicsRouter());
 
-app.listen(PORT, () => {
+// Production: Vite ビルド済みの静的ファイルを配信
+if (isProduction) {
+  const distPath = path.resolve(__dirname, "..", "dist");
+  app.use(express.static(distPath));
+
+  // SPA フォールバック: API 以外のルートは index.html を返す
+  app.get("/{*splat}", (_req, res) => {
+    res.sendFile(path.join(distPath, "index.html"));
+  });
+}
+
+const httpServer = createServer(app);
+setupExchangeSocket(httpServer);
+
+httpServer.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);
 });

--- a/server/socket/exchangeHandler.ts
+++ b/server/socket/exchangeHandler.ts
@@ -62,11 +62,12 @@ const validateBumpPayload = (
 export const setupExchangeSocket = (httpServer: HttpServer): SocketIOServer => {
   const pendingBumps: Map<string, BumpSession> = new Map();
 
+  const isProduction = process.env.NODE_ENV === "production";
+
   const io = new SocketIOServer(httpServer, {
-    cors: {
-      origin: "*",
-      methods: ["GET", "POST"],
-    },
+    cors: isProduction
+      ? undefined
+      : { origin: "*", methods: ["GET", "POST"] },
   });
 
   io.on("connection", (socket) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 


### PR DESCRIPTION
## Summary
- Expressでビルド済みフロントエンドの静的ファイルを配信するよう設定
- HTTP Server化してSocket.IOを統合（未使用だったexchangeHandlerを接続）
- `render.yaml`（Render Blueprint）を作成
- `start`スクリプト追加、`tsx`をdependenciesに移動
- Socket.IO CORSをproduction環境では無効化（同一オリジン）
- vite.config.tsのvitest型参照修正（既存ビルドエラー）

## Test plan
- [x] `npm run build` 成功
- [x] 全69テスト通過
- [x] 本番モードで `/api/health` → 200
- [x] 本番モードで `/` 静的ファイル配信 → 200
- [x] 本番モードで `/share` SPAフォールバック → 200

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)