### PR TITLE
feat: AI APIをOpenAIに切り替え

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,1 @@
-ANTHROPIC_API_KEY=your_api_key_here
-PORT=3001
+OPENAI_API_KEY=your_api_key_here

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,17 @@
       "name": "jimoto-meishi-app",
       "version": "0.0.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.78.0",
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
+        "openai": "^6.29.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.1",
         "socket.io": "^4.8.3",
-        "socket.io-client": "^4.8.3"
+        "socket.io-client": "^4.8.3",
+        "tsx": "^4.21.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -41,7 +42,6 @@
         "postcss": "^8.5.8",
         "supertest": "^7.2.2",
         "tailwindcss": "^4.2.1",
-        "tsx": "^4.21.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.56.1",
         "vite": "^8.0.0",
@@ -64,24 +64,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.78.0",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -310,6 +292,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -507,7 +490,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2374,7 +2356,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2905,7 +2886,6 @@
     },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -3245,17 +3225,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "dev": true,
@@ -3569,6 +3538,27 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.29.0.tgz",
+      "integrity": "sha512-YxoArl2BItucdO89/sN6edksV0x47WUTgkgVfCgX7EuEMhbirENsgYe5oO4LTjBL9PtdKtk2WqND1gSLcTd2yw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {
@@ -3933,7 +3923,6 @@
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -4482,10 +4471,6 @@
         "tree-kill": "cli.js"
       }
     },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "dev": true,
@@ -4504,7 +4489,6 @@
     },
     "node_modules/tsx": {
       "version": "4.21.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -4524,7 +4508,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.78.0",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "openai": "^6.29.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/render.yaml
+++ b/render.yaml
@@ -8,5 +8,5 @@ services:
     envVars:
       - key: NODE_ENV
         value: production
-      - key: ANTHROPIC_API_KEY
+      - key: OPENAI_API_KEY
         sync: false

--- a/server/routes/generateTopics.test.ts
+++ b/server/routes/generateTopics.test.ts
@@ -3,11 +3,11 @@ import express from "express";
 import request from "supertest";
 import { createGenerateTopicsRouter } from "./generateTopics";
 
-// Anthropic SDK のモック
+// OpenAI SDK のモック
 const mockCreate = vi.fn();
-vi.mock("@anthropic-ai/sdk", () => ({
+vi.mock("openai", () => ({
   default: class {
-    messages = { create: mockCreate };
+    chat = { completions: { create: mockCreate } };
   },
 }));
 
@@ -35,10 +35,11 @@ describe("POST /api/generate-topics", () => {
 
   it("有効な都道府県名で3〜5個のTopicが返る", async () => {
     mockCreate.mockResolvedValue({
-      content: [
+      choices: [
         {
-          type: "text",
-          text: JSON.stringify(mockTopicsResponse),
+          message: {
+            content: JSON.stringify(mockTopicsResponse),
+          },
         },
       ],
     });
@@ -90,10 +91,11 @@ describe("POST /api/generate-topics", () => {
 
   it("レスポンスがTopic型（id, text, category）に準拠している", async () => {
     mockCreate.mockResolvedValue({
-      content: [
+      choices: [
         {
-          type: "text",
-          text: JSON.stringify(mockTopicsResponse),
+          message: {
+            content: JSON.stringify(mockTopicsResponse),
+          },
         },
       ],
     });
@@ -116,10 +118,11 @@ describe("POST /api/generate-topics", () => {
 
   it("47都道府県すべてが有効な入力として受け付けられる", async () => {
     mockCreate.mockResolvedValue({
-      content: [
+      choices: [
         {
-          type: "text",
-          text: JSON.stringify(mockTopicsResponse),
+          message: {
+            content: JSON.stringify(mockTopicsResponse),
+          },
         },
       ],
     });

--- a/server/routes/generateTopics.ts
+++ b/server/routes/generateTopics.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
-import Anthropic from "@anthropic-ai/sdk";
+import OpenAI from "openai";
 import type { Topic } from "../../src/types";
 
 const PREFECTURES = [
@@ -52,7 +52,7 @@ const parseTopicsFromResponse = (responseText: string): ReadonlyArray<Topic> => 
 
 export const createGenerateTopicsRouter = (): Router => {
   const router = Router();
-  const client = new Anthropic();
+  const client = new OpenAI();
 
   router.post("/", async (req: Request, res: Response): Promise<void> => {
     const { prefecture } = req.body as { prefecture: unknown };
@@ -65,8 +65,8 @@ export const createGenerateTopicsRouter = (): Router => {
     }
 
     try {
-      const message = await client.messages.create({
-        model: "claude-haiku-4-5-20241022",
+      const completion = await client.chat.completions.create({
+        model: "gpt-4o-mini",
         max_tokens: 1024,
         messages: [
           {
@@ -76,15 +76,15 @@ export const createGenerateTopicsRouter = (): Router => {
         ],
       });
 
-      const textBlock = message.content.find((block) => block.type === "text");
-      if (!textBlock || textBlock.type !== "text") {
+      const content = completion.choices[0]?.message?.content;
+      if (!content) {
         res.status(500).json({
           error: "AIからのレスポンスを取得できませんでした。再試行してください。",
         });
         return;
       }
 
-      const topics = parseTopicsFromResponse(textBlock.text);
+      const topics = parseTopicsFromResponse(content);
 
       res.json({ topics, prefecture });
     } catch (error) {


### PR DESCRIPTION
## Summary
- `@anthropic-ai/sdk` → `openai` に依存パッケージ変更
- トピック生成APIを OpenAI Chat Completions API (`gpt-4o-mini`) に移行
- 環境変数を `ANTHROPIC_API_KEY` → `OPENAI_API_KEY` に変更
- `render.yaml`・`.env.example` を更新
- テストのモックをOpenAI形式に更新

## Test plan
- [x] `npm run build` 成功
- [x] 全69テスト通過
- [x] 実際にOpenAI APIでトピック生成を確認済み（大阪府）

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)