### PR TITLE
fix: Renderビルドでdevdependenciesを含めるよう修正

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: jimoto-meishi-app
     runtime: node
     plan: free
-    buildCommand: npm install && npm run build
+    buildCommand: npm install --include=dev && npm run build
     startCommand: NODE_ENV=production npx tsx server/index.ts
     envVars:
       - key: NODE_ENV


### PR DESCRIPTION
## Summary
- Renderのビルド時に `NODE_ENV=production` が設定されていると `npm install` がdevDependenciesをスキップし、vite/typescript等が見つからずビルド失敗する
- `npm install --include=dev` に変更して修正

## Test plan
- [ ] Renderで再デプロイしてビルド成功を確認

Relates to #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)