### PR TITLE
fix: Renderビルド時のNODE_ENV問題を修正

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,10 +3,8 @@ services:
     name: jimoto-meishi-app
     runtime: node
     plan: free
-    buildCommand: npm install --include=dev && npm run build
+    buildCommand: NODE_ENV=development npm install && npm run build
     startCommand: NODE_ENV=production npx tsx server/index.ts
     envVars:
-      - key: NODE_ENV
-        value: production
       - key: OPENAI_API_KEY
         sync: false


### PR DESCRIPTION
## Summary
- `envVars` の `NODE_ENV=production` がビルド時にも適用され、`npm install` がdevDependencies（vite, typescript等）をスキップしていた
- ビルドコマンドで `NODE_ENV=development` を明示し、`envVars` から `NODE_ENV` を削除
- `NODE_ENV=production` は起動時（startCommand）のみ適用

## Test plan
- [ ] Renderで再デプロイしてビルド成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)