### PR TITLE
feat: 名刺の再表示機能を追加

### DIFF
--- a/src/pages/MeishiPreviewPage.tsx
+++ b/src/pages/MeishiPreviewPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import type { MeishiData } from "../types";
 import {
@@ -6,6 +6,8 @@ import {
   loadSelectedTopics,
   loadPartnerMeishi,
   clearPartnerMeishi,
+  saveMyMeishi,
+  loadMyMeishi,
 } from "../utils/appStorage";
 
 function createMeishiId() {
@@ -23,17 +25,24 @@ export function MeishiPreviewPage() {
   const partnerMeishi = loadPartnerMeishi();
 
   const meishi = useMemo<MeishiData | null>(() => {
-    if (!prefecture || topics.length === 0) {
-      return null;
+    if (prefecture && topics.length > 0) {
+      return {
+        id: createMeishiId(),
+        prefecture,
+        topics,
+        createdAt: new Date().toISOString(),
+      };
     }
 
-    return {
-      id: createMeishiId(),
-      prefecture,
-      topics,
-      createdAt: new Date().toISOString(),
-    };
+    // sessionStorageにデータがなければlocalStorageから復元
+    return loadMyMeishi();
   }, [prefecture, topics]);
+
+  useEffect(() => {
+    if (meishi) {
+      saveMyMeishi(meishi);
+    }
+  }, [meishi]);
 
   if (!meishi) {
     return (

--- a/src/pages/PrefectureSelectPage.tsx
+++ b/src/pages/PrefectureSelectPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { saveSelectedPrefecture } from "../utils/appStorage";
+import { saveSelectedPrefecture, loadMyMeishi } from "../utils/appStorage";
 
 // 地方ごとに都道府県をグループ化
 const PREFECTURE_GROUPS = [
@@ -37,6 +37,7 @@ const PREFECTURE_GROUPS = [
 export function PrefectureSelectPage() {
   const navigate = useNavigate();
   const [selectedPrefecture, setSelectedPrefecture] = useState<string | null>(null);
+  const savedMeishi = loadMyMeishi();
 
   const handleNext = () => {
     if (selectedPrefecture) {
@@ -51,6 +52,26 @@ export function PrefectureSelectPage() {
         <h2 className="text-2xl font-bold text-gray-800 mb-2">出身地はどこ？</h2>
         <p className="text-sm text-gray-500">あなたの地元の話題で盛り上がりましょう</p>
       </div>
+
+      {savedMeishi && (
+        <div className="mb-4">
+          <button
+            onClick={() => navigate("/preview")}
+            className="w-full rounded-2xl border border-orange-200 bg-orange-50 px-5 py-4 text-left transition hover:bg-orange-100 active:scale-[0.98]"
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs font-semibold tracking-wide text-orange-500">前回の名刺があります</p>
+                <p className="mt-1 text-lg font-bold text-gray-900">{savedMeishi.prefecture}</p>
+                <p className="mt-0.5 text-xs text-gray-500">ネタ {savedMeishi.topics.length}件</p>
+              </div>
+              <svg className="h-5 w-5 text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </div>
+          </button>
+        </div>
+      )}
 
       <div className="flex-1 overflow-y-auto space-y-6 scrollbar-hide">
         {PREFECTURE_GROUPS.map((group) => (

--- a/src/utils/appStorage.ts
+++ b/src/utils/appStorage.ts
@@ -3,6 +3,7 @@ import type { MeishiData, TopicWithStance } from "../types";
 const PREFECTURE_KEY = "jimoto:selectedPrefecture";
 const TOPICS_KEY = "jimoto:selectedTopics";
 const PARTNER_MEISHI_KEY = "jimoto:partnerMeishi";
+const MY_MEISHI_KEY = "jimoto:myMeishi";
 
 function isBrowser() {
   return typeof window !== "undefined";
@@ -82,4 +83,30 @@ export function clearPartnerMeishi() {
   }
 
   window.sessionStorage.removeItem(PARTNER_MEISHI_KEY);
+}
+
+export function saveMyMeishi(meishi: MeishiData) {
+  if (!isBrowser()) {
+    return;
+  }
+
+  window.localStorage.setItem(MY_MEISHI_KEY, JSON.stringify(meishi));
+}
+
+export function loadMyMeishi(): MeishiData | null {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  const raw = window.localStorage.getItem(MY_MEISHI_KEY);
+
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as MeishiData;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary
- localStorageに作成済み名刺を永続保存し、ブラウザを閉じても名刺データを保持
- ホーム画面（出身地選択）に「前回の名刺があります」ボタンを表示し、タップでプレビュー画面へ遷移
- sessionStorageにデータがない場合もlocalStorageからフォールバック復元

## Test plan
- [ ] 名刺を作成後、ブラウザを閉じて再度開き、ホーム画面に前回の名刺ボタンが表示されることを確認
- [ ] ボタンをタップして名刺プレビューが正しく表示されることを確認
- [ ] 新しい名刺を作成すると、保存データが上書きされることを確認