### PR TITLE
feat: 名刺作成済みなら自動でプレビュー画面を表示

### DIFF
--- a/src/pages/MeishiPreviewPage.tsx
+++ b/src/pages/MeishiPreviewPage.tsx
@@ -8,6 +8,7 @@ import {
   clearPartnerMeishi,
   saveMyMeishi,
   loadMyMeishi,
+  clearMyMeishi,
 } from "../utils/appStorage";
 
 function createMeishiId() {
@@ -152,10 +153,13 @@ export function MeishiPreviewPage() {
           )}
           <button
             type="button"
-            onClick={() => navigate("/topics")}
+            onClick={() => {
+              clearMyMeishi();
+              navigate("/");
+            }}
             className="rounded-full border border-gray-200 px-5 py-4 font-semibold text-gray-700 transition hover:bg-gray-50"
           >
-            ネタ選択に戻る
+            名刺を作り直す
           </button>
         </div>
       </section>

--- a/src/pages/PrefectureSelectPage.tsx
+++ b/src/pages/PrefectureSelectPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Navigate } from "react-router-dom";
 import { saveSelectedPrefecture, loadMyMeishi } from "../utils/appStorage";
 
 // 地方ごとに都道府県をグループ化
@@ -39,6 +39,11 @@ export function PrefectureSelectPage() {
   const [selectedPrefecture, setSelectedPrefecture] = useState<string | null>(null);
   const savedMeishi = loadMyMeishi();
 
+  // 名刺が保存済みなら自動的にプレビューへリダイレクト
+  if (savedMeishi) {
+    return <Navigate to="/preview" replace />;
+  }
+
   const handleNext = () => {
     if (selectedPrefecture) {
       saveSelectedPrefecture(selectedPrefecture);
@@ -52,26 +57,6 @@ export function PrefectureSelectPage() {
         <h2 className="text-2xl font-bold text-gray-800 mb-2">出身地はどこ？</h2>
         <p className="text-sm text-gray-500">あなたの地元の話題で盛り上がりましょう</p>
       </div>
-
-      {savedMeishi && (
-        <div className="mb-4">
-          <button
-            onClick={() => navigate("/preview")}
-            className="w-full rounded-2xl border border-orange-200 bg-orange-50 px-5 py-4 text-left transition hover:bg-orange-100 active:scale-[0.98]"
-          >
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-xs font-semibold tracking-wide text-orange-500">前回の名刺があります</p>
-                <p className="mt-1 text-lg font-bold text-gray-900">{savedMeishi.prefecture}</p>
-                <p className="mt-0.5 text-xs text-gray-500">ネタ {savedMeishi.topics.length}件</p>
-              </div>
-              <svg className="h-5 w-5 text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </div>
-          </button>
-        </div>
-      )}
 
       <div className="flex-1 overflow-y-auto space-y-6 scrollbar-hide">
         {PREFECTURE_GROUPS.map((group) => (

--- a/src/utils/appStorage.ts
+++ b/src/utils/appStorage.ts
@@ -93,6 +93,14 @@ export function saveMyMeishi(meishi: MeishiData) {
   window.localStorage.setItem(MY_MEISHI_KEY, JSON.stringify(meishi));
 }
 
+export function clearMyMeishi() {
+  if (!isBrowser()) {
+    return;
+  }
+
+  window.localStorage.removeItem(MY_MEISHI_KEY);
+}
+
 export function loadMyMeishi(): MeishiData | null {
   if (!isBrowser()) {
     return null;


### PR DESCRIPTION
## Summary
- ホーム画面(`/`)アクセス時にlocalStorageに名刺があれば `/preview` へ自動リダイレクト
- プレビュー画面の「ネタ選択に戻る」→「名刺を作り直す」に変更（localStorageクリア→作成フローへ）
- `clearMyMeishi` 関数を追加

## 動作フロー
- **初回**: `/` → 出身地選択 → ネタ選択 → 名刺プレビュー（localStorageに保存）
- **2回目以降**: `/` → 自動で名刺プレビューへ
- **作り直したい場合**: プレビュー画面の「名刺を作り直す」ボタン → 作成フローへ

## Test plan
- [ ] 名刺作成後、ブラウザを閉じて再度開くと自動でプレビュー画面が表示されること
- [ ] 「名刺を作り直す」ボタンで出身地選択画面に戻れること
- [ ] 作り直し後は通常の作成フローが動作すること