### PR TITLE
feat: MonzoスタイルのクリーンなモバイルUIに全面刷新

### DIFF
--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -2,11 +2,11 @@ import { Outlet } from "react-router-dom";
 
 export function Layout() {
   return (
-    <div className="min-h-svh flex flex-col bg-white" style={{ paddingTop: "env(safe-area-inset-top)" }}>
-      <header className="bg-gradient-to-r from-orange-500 to-pink-500 text-white px-4 py-3">
-        <h1 className="text-lg font-bold text-center">じもと名刺</h1>
-      </header>
-      <main className="flex-1 px-4 py-6">
+    <div
+      className="flex min-h-svh flex-col bg-[#f8f8f6]"
+      style={{ paddingTop: "env(safe-area-inset-top)" }}
+    >
+      <main className="flex-1">
         <Outlet />
       </main>
     </div>

--- a/src/pages/MeishiPreviewPage.tsx
+++ b/src/pages/MeishiPreviewPage.tsx
@@ -19,6 +19,36 @@ function createMeishiId() {
   return `meishi-${Date.now()}`;
 }
 
+function ShareIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+      <polyline points="16 6 12 2 8 6" />
+      <line x1="12" y1="2" x2="12" y2="15" />
+    </svg>
+  );
+}
+
+function CompareIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M16 3h5v5" />
+      <line x1="21" y1="3" x2="14" y2="10" />
+      <path d="M8 21H3v-5" />
+      <line x1="3" y1="21" x2="10" y2="14" />
+    </svg>
+  );
+}
+
+function RefreshIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="23 4 23 10 17 10" />
+      <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+    </svg>
+  );
+}
+
 export function MeishiPreviewPage() {
   const navigate = useNavigate();
   const prefecture = loadSelectedPrefecture();
@@ -35,7 +65,6 @@ export function MeishiPreviewPage() {
       };
     }
 
-    // sessionStorageにデータがなければlocalStorageから復元
     return loadMyMeishi();
   }, [prefecture, topics]);
 
@@ -47,27 +76,19 @@ export function MeishiPreviewPage() {
 
   if (!meishi) {
     return (
-      <div className="mx-auto flex min-h-[40vh] max-w-md flex-col items-center justify-center px-4 text-center">
-        <div className="rounded-[32px] border border-orange-100 bg-white px-6 py-8 shadow-sm">
-          <p className="text-sm font-semibold tracking-[0.2em] text-orange-500">PREVIEW</p>
-          <h2 className="mt-3 text-2xl font-bold text-gray-900">名刺データがありません</h2>
-          <p className="mt-3 text-sm leading-6 text-gray-500">
+      <div className="mx-auto flex min-h-[60vh] max-w-[420px] flex-col items-center justify-center px-5">
+        <div className="w-full rounded-2xl border border-[#ececea] bg-white p-6">
+          <h2 className="text-center text-lg font-bold text-[#1a1a1a]">名刺データがありません</h2>
+          <p className="mt-2 text-center text-sm text-[#888]">
             先に出身地を選んで、ネタの立場を決めてください。
           </p>
-          <div className="mt-6 flex flex-col gap-3">
+          <div className="mt-5 flex flex-col gap-3">
             <button
               type="button"
               onClick={() => navigate("/")}
-              className="rounded-full bg-linear-to-r from-orange-500 to-pink-500 px-5 py-3 font-bold text-white"
+              className="rounded-xl bg-[#e85d3a] px-5 py-3.5 text-[15px] font-semibold text-white"
             >
               最初からつくる
-            </button>
-            <button
-              type="button"
-              onClick={() => navigate("/topics")}
-              className="rounded-full border border-gray-200 px-5 py-3 font-semibold text-gray-700"
-            >
-              ネタ選択に戻る
             </button>
           </div>
         </div>
@@ -76,93 +97,126 @@ export function MeishiPreviewPage() {
   }
 
   return (
-    <div className="mx-auto flex max-w-md flex-col gap-5 pb-8">
-      <section className="rounded-[28px] bg-linear-to-br from-slate-950 via-slate-900 to-orange-950 px-5 py-6 text-white shadow-xl">
-        <p className="text-xs font-semibold tracking-[0.24em] text-orange-300">JIMOTO MEISHI</p>
-        <div className="mt-4 flex items-start justify-between gap-4">
-          <div>
-            <h2 className="text-3xl font-bold tracking-tight">{meishi.prefecture}</h2>
-            <p className="mt-2 text-sm leading-6 text-white/70">
-              地元では普通。でも外に出ると会話になる、わたしの論点カード。
-            </p>
-          </div>
-          <div className="rounded-2xl border border-white/10 bg-white/10 px-3 py-2 text-right backdrop-blur-sm">
-            <p className="text-[10px] tracking-[0.18em] text-white/50">TOPICS</p>
-            <p className="text-2xl font-bold">{meishi.topics.length}</p>
-          </div>
-        </div>
+    <div className="mx-auto max-w-[420px] pb-8">
+      {/* ── Header ── */}
+      <div className="relative flex items-center justify-center px-6 pt-5 pb-1">
+        <span className="text-[17px] font-semibold text-[#1a1a1a]">じもと名刺</span>
+      </div>
+      <p className="mb-4 text-center text-sm font-medium text-[#888]">
+        {meishi.prefecture}
+      </p>
 
-        <div className="mt-6 space-y-3">
-          {meishi.topics.map(({ topic, agrees }, index) => (
-            <article
-              key={topic.id}
-              className="rounded-2xl border border-white/10 bg-white/8 px-4 py-4 backdrop-blur-sm"
-            >
-              <div className="flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <span className="inline-flex h-7 min-w-7 items-center justify-center rounded-full bg-white/12 px-2 text-xs font-bold">
-                    {index + 1}
-                  </span>
-                  <span className="rounded-full bg-orange-400/15 px-2.5 py-1 text-[11px] font-semibold text-orange-200">
-                    {topic.category}
-                  </span>
-                </div>
+      {/* ── Card Visual ── */}
+      <div className="flex justify-center px-8 pb-6">
+        <div className="relative w-full max-w-[320px] overflow-hidden rounded-2xl bg-gradient-to-br from-[#2d2d3a] via-[#3a3a4a] to-[#2d2d3a] shadow-[0_8px_32px_rgba(0,0,0,.18)]"
+          style={{ aspectRatio: "1.586 / 1" }}
+        >
+          {/* JIMOTO MEISHI label */}
+          <span className="absolute top-4 left-5 text-[10px] font-semibold tracking-[0.2em] text-white/50">
+            JIMOTO MEISHI
+          </span>
+
+          {/* Prefecture */}
+          <h2 className="absolute top-10 left-5 text-2xl font-bold tracking-tight text-white">
+            {meishi.prefecture}
+          </h2>
+
+          {/* Topic count */}
+          <div className="absolute top-4 right-5 text-right">
+            <p className="text-[9px] tracking-[0.15em] text-white/40">TOPICS</p>
+            <p className="text-xl font-bold text-white/80">{meishi.topics.length}</p>
+          </div>
+
+          {/* Decorative accent */}
+          <div className="absolute bottom-4 left-5 right-5 flex items-end justify-between">
+            <span className="text-[11px] font-medium text-white/30">
+              {new Date(meishi.createdAt).toLocaleDateString("ja-JP")}
+            </span>
+            <div className="flex gap-1">
+              {meishi.topics.map(({ agrees }, i) => (
                 <span
-                  className={`rounded-full px-3 py-1 text-xs font-bold ${
-                    agrees
-                      ? "bg-emerald-400/20 text-emerald-200"
-                      : "bg-sky-400/20 text-sky-200"
+                  key={i}
+                  className={`inline-block h-2 w-2 rounded-full ${
+                    agrees ? "bg-emerald-400/60" : "bg-orange-400/60"
                   }`}
-                >
-                  {agrees ? "わかる派" : "違う派"}
-                </span>
-              </div>
-              <p className="mt-3 text-sm leading-6 text-white/92">{topic.text}</p>
-            </article>
-          ))}
+                />
+              ))}
+            </div>
+          </div>
         </div>
-      </section>
+      </div>
 
-      <section className="rounded-[28px] border border-gray-100 bg-white p-5 shadow-sm">
-        <h3 className="text-lg font-bold text-gray-900">この名刺でよければ共有へ</h3>
-        <p className="mt-2 text-sm leading-6 text-gray-500">
-          QR表示とURL共有は次の画面で行います。気になるなら一度ネタ選択に戻って調整できます。
-        </p>
-        <div className="mt-5 flex flex-col gap-3">
-          {partnerMeishi ? (
-            <button
-              type="button"
-              onClick={() => {
-                clearPartnerMeishi();
-                navigate("/comparison", {
-                  state: { myMeishi: meishi, partnerMeishi },
-                });
-              }}
-              className="rounded-full bg-linear-to-r from-emerald-500 to-teal-500 px-5 py-4 text-lg font-bold text-white shadow-lg transition hover:scale-[1.01] active:scale-95"
-            >
-              名刺を比較する
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={() => navigate("/share", { state: { meishi } })}
-              className="rounded-full bg-linear-to-r from-orange-500 to-pink-500 px-5 py-4 text-lg font-bold text-white shadow-lg transition hover:scale-[1.01] active:scale-95"
-            >
-              この名刺を共有する
-            </button>
-          )}
+      {/* ── Action Buttons ── */}
+      <div className="grid grid-cols-2 gap-3 px-5 pb-4">
+        {partnerMeishi ? (
           <button
             type="button"
             onClick={() => {
-              clearMyMeishi();
-              navigate("/");
+              clearPartnerMeishi();
+              navigate("/comparison", {
+                state: { myMeishi: meishi, partnerMeishi },
+              });
             }}
-            className="rounded-full border border-gray-200 px-5 py-4 font-semibold text-gray-700 transition hover:bg-gray-50"
+            className="flex flex-col items-center gap-2 rounded-2xl bg-[#e85d3a] px-4 py-5 text-[15px] font-semibold text-white"
           >
-            名刺を作り直す
+            <CompareIcon />
+            名刺を比較
           </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => navigate("/share", { state: { meishi } })}
+            className="flex flex-col items-center gap-2 rounded-2xl bg-[#e85d3a] px-4 py-5 text-[15px] font-semibold text-white"
+          >
+            <ShareIcon />
+            共有する
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => {
+            clearMyMeishi();
+            navigate("/");
+          }}
+          className="flex flex-col items-center gap-2 rounded-2xl border border-[#e0e0dc] bg-white px-4 py-5 text-[15px] font-semibold text-[#e85d3a]"
+        >
+          <RefreshIcon />
+          作り直す
+        </button>
+      </div>
+
+      {/* ── Topics Section ── */}
+      <div className="mx-5 rounded-2xl border border-[#ececea] bg-white p-5">
+        <h3 className="mb-4 text-base font-bold text-[#1a1a1a]">ネタ一覧</h3>
+        <div className="divide-y divide-[#f0f0ee]">
+          {meishi.topics.map(({ topic, agrees }, index) => (
+            <div key={topic.id} className="flex items-start justify-between gap-3 py-3.5">
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-[#f0f0ee] text-[11px] font-bold text-[#888]">
+                    {index + 1}
+                  </span>
+                  <span className="text-[11px] font-semibold text-[#888]">
+                    {topic.category}
+                  </span>
+                </div>
+                <p className="mt-1.5 text-[15px] leading-relaxed text-[#1a1a1a]">
+                  {topic.text}
+                </p>
+              </div>
+              <span
+                className={`mt-0.5 shrink-0 rounded-full px-2.5 py-1 text-xs font-bold ${
+                  agrees
+                    ? "bg-emerald-50 text-emerald-600"
+                    : "bg-orange-50 text-orange-600"
+                }`}
+              >
+                {agrees ? "わかる" : "違う"}
+              </span>
+            </div>
+          ))}
         </div>
-      </section>
+      </div>
     </div>
   );
 }

--- a/src/pages/PrefectureSelectPage.tsx
+++ b/src/pages/PrefectureSelectPage.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { useNavigate, Navigate } from "react-router-dom";
 import { saveSelectedPrefecture, loadMyMeishi } from "../utils/appStorage";
 
-// 地方ごとに都道府県をグループ化
 const PREFECTURE_GROUPS = [
   {
     region: "北海道・東北",
@@ -39,7 +38,6 @@ export function PrefectureSelectPage() {
   const [selectedPrefecture, setSelectedPrefecture] = useState<string | null>(null);
   const savedMeishi = loadMyMeishi();
 
-  // 名刺が保存済みなら自動的にプレビューへリダイレクト
   if (savedMeishi) {
     return <Navigate to="/preview" replace />;
   }
@@ -52,16 +50,20 @@ export function PrefectureSelectPage() {
   };
 
   return (
-    <div className="flex flex-col h-full max-w-md mx-auto relative pb-20">
-      <div className="text-center mb-6">
-        <h2 className="text-2xl font-bold text-gray-800 mb-2">出身地はどこ？</h2>
-        <p className="text-sm text-gray-500">あなたの地元の話題で盛り上がりましょう</p>
+    <div className="mx-auto flex h-full max-w-[420px] flex-col pb-24">
+      {/* Header */}
+      <div className="px-6 pt-5 pb-1 text-center">
+        <h2 className="text-[17px] font-semibold text-[#1a1a1a]">出身地はどこ？</h2>
       </div>
+      <p className="mb-5 text-center text-sm font-medium text-[#888]">
+        あなたの地元の話題で盛り上がりましょう
+      </p>
 
-      <div className="flex-1 overflow-y-auto space-y-6 scrollbar-hide">
+      {/* Prefecture groups */}
+      <div className="flex-1 space-y-3 overflow-y-auto px-5 scrollbar-hide">
         {PREFECTURE_GROUPS.map((group) => (
-          <div key={group.region} className="bg-white rounded-2xl p-4 shadow-sm border border-gray-100">
-            <h3 className="text-md font-semibold text-pink-500 mb-3 border-b border-pink-100 pb-2">
+          <div key={group.region} className="rounded-2xl border border-[#ececea] bg-white p-4">
+            <h3 className="mb-3 border-b border-[#f0f0ee] pb-2 text-sm font-bold text-[#e85d3a]">
               {group.region}
             </h3>
             <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
@@ -71,14 +73,11 @@ export function PrefectureSelectPage() {
                   <button
                     key={pref}
                     onClick={() => setSelectedPrefecture(pref)}
-                    className={`
-                      min-h-[44px] py-2.5 px-1 text-sm rounded-lg transition-all duration-200 ease-in-out font-medium
-                      ${
-                        isSelected
-                          ? "bg-gradient-to-r from-orange-500 to-pink-500 text-white shadow-md transform scale-105"
-                          : "bg-gray-50 text-gray-700 hover:bg-orange-50 active:bg-orange-100 border border-transparent shadow-sm"
-                      }
-                    `}
+                    className={`min-h-[44px] rounded-xl px-1 py-2.5 text-sm font-medium transition-all duration-200 ${
+                      isSelected
+                        ? "bg-[#e85d3a] text-white shadow-md"
+                        : "border border-[#e0e0dc] bg-[#f8f8f6] text-[#555] active:bg-[#e8e8e4]"
+                    }`}
                   >
                     {pref}
                   </button>
@@ -89,28 +88,22 @@ export function PrefectureSelectPage() {
         ))}
       </div>
 
-      {/* フローティングアクションボタンエリア */}
-      <div className="fixed bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-white via-white to-transparent" style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 1rem)" }}>
-        <div className="max-w-md mx-auto">
+      {/* Floating action button */}
+      <div
+        className="fixed right-0 bottom-0 left-0 bg-gradient-to-t from-[#f8f8f6] via-[#f8f8f6] to-transparent p-4"
+        style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 1rem)" }}
+      >
+        <div className="mx-auto max-w-[420px]">
           <button
             onClick={handleNext}
             disabled={!selectedPrefecture}
-            className={`
-              w-full py-4 rounded-full font-bold text-lg shadow-lg flex items-center justify-center
-              transition-all duration-300 ease-out
-              ${
-                selectedPrefecture
-                  ? "bg-gradient-to-r from-orange-500 to-pink-500 text-white transform hover:scale-[1.02] active:scale-95 cursor-pointer"
-                  : "bg-gray-200 text-gray-400 cursor-not-allowed"
-              }
-            `}
+            className={`flex w-full items-center justify-center rounded-2xl py-4 text-[15px] font-semibold shadow-lg transition-all duration-200 ${
+              selectedPrefecture
+                ? "bg-[#e85d3a] text-white active:scale-[0.98]"
+                : "bg-[#e0e0dc] text-[#aaa] cursor-not-allowed"
+            }`}
           >
             {selectedPrefecture ? `${selectedPrefecture}で決定！` : "出身地を選択してください"}
-            {selectedPrefecture && (
-              <svg className="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            )}
           </button>
         </div>
       </div>

--- a/src/pages/SharePage.tsx
+++ b/src/pages/SharePage.tsx
@@ -19,7 +19,6 @@ export function SharePage() {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // フォールバック: 古いブラウザ対応
       const textArea = document.createElement("textarea");
       textArea.value = shareUrl;
       document.body.appendChild(textArea);
@@ -46,70 +45,80 @@ export function SharePage() {
 
   if (!meishi) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[40vh] px-4">
-        <p className="text-gray-600 text-lg mb-4">名刺データがありません</p>
-        <button
-          onClick={() => navigate("/")}
-          className="px-6 py-3 min-h-[44px] bg-blue-500 text-white rounded-xl font-bold"
-        >
-          名刺を作る
-        </button>
+      <div className="mx-auto flex min-h-[60vh] max-w-[420px] flex-col items-center justify-center px-5">
+        <div className="w-full rounded-2xl border border-[#ececea] bg-white p-6 text-center">
+          <h2 className="text-lg font-bold text-[#1a1a1a]">名刺データがありません</h2>
+          <button
+            onClick={() => navigate("/")}
+            className="mt-4 w-full rounded-xl bg-[#e85d3a] px-5 py-3.5 text-[15px] font-semibold text-white"
+          >
+            名刺を作る
+          </button>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col items-center px-4 py-8 max-w-md mx-auto">
-      <h1 className="text-2xl font-bold mb-2">名刺を共有しよう</h1>
-      <p className="text-gray-500 text-sm mb-8">
+    <div className="mx-auto max-w-[420px] pb-8">
+      {/* Header */}
+      <div className="px-6 pt-5 pb-1 text-center">
+        <span className="text-[17px] font-semibold text-[#1a1a1a]">名刺を共有</span>
+      </div>
+      <p className="mb-6 text-center text-sm font-medium text-[#888]">
         QRコードを見せるか、URLを送ってね
       </p>
 
-      {/* QRコード */}
-      <div className="bg-white p-6 rounded-2xl shadow-lg mb-8">
+      {/* QR Code */}
+      <div className="mx-5 mb-4 flex justify-center rounded-2xl border border-[#ececea] bg-white p-6">
         <QRCodeSVG
           value={shareUrl}
-          size={220}
+          size={200}
           level="M"
           includeMargin
         />
       </div>
 
-      {/* 共有URL表示 & コピー */}
-      <div className="w-full mb-6">
+      {/* URL & Copy */}
+      <div className="mx-5 mb-4 rounded-2xl border border-[#ececea] bg-white p-5">
+        <h3 className="mb-3 text-base font-bold text-[#1a1a1a]">共有URL</h3>
         <div
-          onClick={handleCopy}
-          className="w-full p-4 bg-gray-100 rounded-xl text-sm text-gray-700 break-all cursor-pointer hover:bg-gray-200 transition-colors"
+          onClick={() => void handleCopy()}
+          className="cursor-pointer rounded-xl bg-[#f8f8f6] p-3 text-[13px] leading-relaxed text-[#555] break-all transition hover:bg-[#f0f0ee]"
         >
           {shareUrl}
         </div>
         <button
-          onClick={handleCopy}
-          className={`w-full mt-3 py-3 rounded-xl font-bold text-white transition-colors ${
-            copied ? "bg-green-500" : "bg-blue-500 hover:bg-blue-600"
+          onClick={() => void handleCopy()}
+          className={`mt-3 w-full rounded-xl py-3.5 text-[15px] font-semibold text-white transition ${
+            copied ? "bg-emerald-500" : "bg-[#e85d3a]"
           }`}
         >
           {copied ? "コピーしました！" : "URLをコピー"}
         </button>
       </div>
 
-      {/* ネイティブ共有（対応端末のみ） */}
+      {/* Native share */}
       {typeof navigator !== "undefined" && "share" in navigator && (
-        <button
-          onClick={handleNativeShare}
-          className="w-full py-3 bg-purple-500 hover:bg-purple-600 text-white rounded-xl font-bold mb-6 transition-colors"
-        >
-          共有メニューで送る
-        </button>
+        <div className="mx-5 mb-4">
+          <button
+            onClick={() => void handleNativeShare()}
+            className="w-full rounded-2xl border border-[#e0e0dc] bg-white px-4 py-4 text-[15px] font-semibold text-[#e85d3a] transition"
+          >
+            共有メニューで送る
+          </button>
+        </div>
       )}
 
-      {/* トップに戻る */}
-      <button
-        onClick={() => navigate("/")}
-        className="w-full py-3 border-2 border-gray-300 text-gray-600 rounded-xl font-bold hover:bg-gray-50 transition-colors"
-      >
-        トップに戻る
-      </button>
+      {/* Back */}
+      <div className="mx-5">
+        <button
+          onClick={() => navigate("/preview")}
+          className="w-full rounded-2xl border border-[#e0e0dc] bg-white px-4 py-4 text-[15px] font-semibold text-[#555] transition"
+        >
+          名刺に戻る
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/pages/TopicGenerationPage.tsx
+++ b/src/pages/TopicGenerationPage.tsx
@@ -130,57 +130,52 @@ export function TopicGenerationPage() {
   }
 
   return (
-    <div className="mx-auto flex h-full max-w-md flex-col pb-24">
-      <section className="relative overflow-hidden rounded-[28px] bg-linear-to-br from-orange-500 via-rose-500 to-pink-500 px-5 py-6 text-white shadow-lg">
-        <div className="absolute -right-8 -top-10 h-28 w-28 rounded-full bg-white/15 blur-2xl" />
-        <div className="absolute -bottom-10 left-4 h-24 w-24 rounded-full bg-amber-200/20 blur-2xl" />
-        <p className="relative text-xs font-semibold tracking-[0.2em] text-white/75">TOPIC GENERATOR</p>
-        <h2 className="relative mt-2 text-2xl font-bold leading-tight">
-          {prefecture}の
-          <br />
-          あるある、どっち派？
-        </h2>
-        <p className="relative mt-3 text-sm leading-6 text-white/85">
-          AIが「本人は普通だと思っているけど、話すと盛り上がる」ネタを集めました。
-        </p>
-        <div className="relative mt-5 flex items-center justify-between rounded-2xl bg-white/14 px-4 py-3 backdrop-blur-sm">
-          <div>
-            <p className="text-xs text-white/70">選択状況</p>
-            <p className="text-sm font-semibold">
-              {completedCount} / {topics.length || 5} 個
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => void handleRegenerate()}
-            disabled={isLoading}
-            className="rounded-full border border-white/30 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60 min-h-[44px]"
-          >
-            別のネタにする
-          </button>
-        </div>
-      </section>
+    <div className="mx-auto flex h-full max-w-[420px] flex-col pb-24">
+      {/* Header */}
+      <div className="px-6 pt-5 pb-1 text-center">
+        <span className="text-[17px] font-semibold text-[#1a1a1a]">ネタ選択</span>
+      </div>
+      <p className="mb-4 text-center text-sm font-medium text-[#888]">{prefecture}</p>
 
-      <section className="mt-5 flex-1 space-y-4 overflow-y-auto scrollbar-hide">
+      {/* Progress & Regenerate */}
+      <div className="mx-5 mb-4 flex items-center justify-between rounded-2xl border border-[#ececea] bg-white px-4 py-3">
+        <div>
+          <p className="text-xs text-[#888]">選択状況</p>
+          <p className="text-sm font-semibold text-[#1a1a1a]">
+            {completedCount} / {topics.length || 5} 個
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void handleRegenerate()}
+          disabled={isLoading}
+          className="min-h-[44px] rounded-xl border border-[#e0e0dc] px-4 py-2.5 text-sm font-semibold text-[#e85d3a] transition disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          別のネタにする
+        </button>
+      </div>
+
+      {/* Topics */}
+      <section className="flex-1 space-y-3 overflow-y-auto px-5 scrollbar-hide">
         {isLoading && (
-          <div className="rounded-[28px] border border-orange-100 bg-white p-6 shadow-sm">
+          <div className="rounded-2xl border border-[#ececea] bg-white p-5">
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 animate-pulse rounded-full bg-gradient-to-br from-orange-400 to-pink-500" />
+              <div className="h-8 w-8 animate-pulse rounded-full bg-[#e85d3a]/30" />
               <div>
-                <p className="text-sm font-semibold text-gray-800">ネタを生成中です</p>
-                <p className="text-sm text-gray-500">{prefecture}らしい論点をまとめています…</p>
+                <p className="text-sm font-semibold text-[#1a1a1a]">ネタを生成中です</p>
+                <p className="text-xs text-[#888]">{prefecture}らしい論点をまとめています…</p>
               </div>
             </div>
-            <div className="mt-5 space-y-3">
+            <div className="mt-4 space-y-3">
               {[0, 1, 2].map((item) => (
-                <div key={item} className="h-20 animate-pulse rounded-2xl bg-gray-100" />
+                <div key={item} className="h-16 animate-pulse rounded-xl bg-[#f0f0ee]" />
               ))}
             </div>
           </div>
         )}
 
         {!isLoading && errorMessage && (
-          <div className="rounded-[28px] border border-red-100 bg-red-50 p-5 text-sm text-red-700 shadow-sm">
+          <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
             <p className="font-semibold">生成できませんでした</p>
             <p className="mt-1">{errorMessage}</p>
           </div>
@@ -194,44 +189,46 @@ export function TopicGenerationPage() {
             return (
               <article
                 key={topic.id}
-                className="rounded-[28px] border border-gray-100 bg-white p-5 shadow-sm transition hover:shadow-md"
+                className="rounded-2xl border border-[#ececea] bg-white p-4"
               >
                 <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="text-xs font-semibold tracking-[0.16em] text-orange-500">
-                      TOPIC {index + 1}
-                    </p>
-                    <span className="mt-2 inline-flex rounded-full bg-orange-50 px-3 py-1 text-xs font-medium text-orange-700">
+                  <div className="flex items-center gap-2">
+                    <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-[#f0f0ee] text-[11px] font-bold text-[#888]">
+                      {index + 1}
+                    </span>
+                    <span className="text-[11px] font-semibold text-[#888]">
                       {topic.category}
                     </span>
                   </div>
-                  <div
-                    className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                  <span
+                    className={`rounded-full px-2.5 py-1 text-xs font-bold ${
                       selectedStance === null
-                        ? "bg-gray-100 text-gray-500"
+                        ? "bg-[#f0f0ee] text-[#aaa]"
                         : selectedStance
-                          ? "bg-emerald-100 text-emerald-700"
-                          : "bg-sky-100 text-sky-700"
+                          ? "bg-emerald-50 text-emerald-600"
+                          : "bg-orange-50 text-orange-600"
                     }`}
                   >
-                    {selectedStance === null ? "未選択" : selectedStance ? "わかる派" : "違う派"}
-                  </div>
+                    {selectedStance === null ? "未選択" : selectedStance ? "わかる" : "違う"}
+                  </span>
                 </div>
 
-                <p className="mt-4 text-base font-semibold leading-7 text-gray-900">{topic.text}</p>
+                <p className="mt-3 text-[15px] font-semibold leading-relaxed text-[#1a1a1a]">
+                  {topic.text}
+                </p>
 
-                <div className="mt-5 grid grid-cols-2 gap-3">
+                <div className="mt-4 grid grid-cols-2 gap-2">
                   <button
                     type="button"
                     onClick={() => handleSelectStance(topic.id, true)}
-                    className={`rounded-2xl px-4 py-4 text-left transition ${
+                    className={`rounded-xl px-3 py-3 text-left transition ${
                       selectedStance === true
-                        ? "bg-emerald-500 text-white shadow-md"
-                        : "bg-emerald-50 text-emerald-900 hover:bg-emerald-100"
+                        ? "bg-emerald-500 text-white"
+                        : "border border-[#e0e0dc] bg-[#f8f8f6] text-[#555]"
                     }`}
                   >
                     <p className="text-sm font-bold">{STANCE_COPY.agree.label}</p>
-                    <p className={`mt-1 text-xs ${selectedStance === true ? "text-white/80" : "text-emerald-700"}`}>
+                    <p className={`mt-0.5 text-[11px] ${selectedStance === true ? "text-white/80" : "text-[#888]"}`}>
                       {STANCE_COPY.agree.description}
                     </p>
                   </button>
@@ -239,14 +236,14 @@ export function TopicGenerationPage() {
                   <button
                     type="button"
                     onClick={() => handleSelectStance(topic.id, false)}
-                    className={`rounded-2xl px-4 py-4 text-left transition ${
+                    className={`rounded-xl px-3 py-3 text-left transition ${
                       selectedStance === false
-                        ? "bg-sky-500 text-white shadow-md"
-                        : "bg-sky-50 text-sky-900 hover:bg-sky-100"
+                        ? "bg-[#e85d3a] text-white"
+                        : "border border-[#e0e0dc] bg-[#f8f8f6] text-[#555]"
                     }`}
                   >
                     <p className="text-sm font-bold">{STANCE_COPY.disagree.label}</p>
-                    <p className={`mt-1 text-xs ${selectedStance === false ? "text-white/80" : "text-sky-700"}`}>
+                    <p className={`mt-0.5 text-[11px] ${selectedStance === false ? "text-white/80" : "text-[#888]"}`}>
                       {STANCE_COPY.disagree.description}
                     </p>
                   </button>
@@ -256,16 +253,20 @@ export function TopicGenerationPage() {
           })}
       </section>
 
-      <div className="fixed bottom-0 left-0 right-0 bg-gradient-to-t from-white via-white to-transparent px-4 pt-4" style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 1rem)" }}>
-        <div className="mx-auto max-w-md">
+      {/* Floating action */}
+      <div
+        className="fixed right-0 bottom-0 left-0 bg-gradient-to-t from-[#f8f8f6] via-[#f8f8f6] to-transparent p-4"
+        style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 1rem)" }}
+      >
+        <div className="mx-auto max-w-[420px]">
           <button
             type="button"
             onClick={handleNext}
             disabled={!canProceed}
-            className={`flex w-full items-center justify-center rounded-full py-4 text-lg font-bold shadow-lg transition ${
+            className={`flex w-full items-center justify-center rounded-2xl py-4 text-[15px] font-semibold shadow-lg transition ${
               canProceed
-                ? "bg-linear-to-r from-orange-500 to-pink-500 text-white hover:scale-[1.01] active:scale-95"
-                : "bg-gray-200 text-gray-400"
+                ? "bg-[#e85d3a] text-white active:scale-[0.98]"
+                : "bg-[#e0e0dc] text-[#aaa] cursor-not-allowed"
             }`}
           >
             {canProceed ? "この内容で名刺をつくる" : "全てのネタで立場を選んでください"}


### PR DESCRIPTION
## Summary
- Monzoアプリのカード詳細画面をデザインリファレンスとして、全画面をクリーンなモバイルUIに統一
- オフホワイト背景 + 白カードセクション + 角丸 + 薄いボーダーのデザインシステム
- アクセントカラー: `#e85d3a`（オレンジ系）

## 変更画面
| 画面 | 主な変更 |
|------|----------|
| Layout | グラデーションヘッダー廃止、オフホワイト背景に変更 |
| MeishiPreviewPage | カード中心レイアウト、2カラムアクションボタン、ネタ一覧セクション |
| PrefectureSelectPage | 統一デザイン、角丸ボタン |
| TopicGenerationPage | 統一デザイン、ステータスバー |
| SharePage | 統一デザイン、QR/URL共有 |

## Test plan
- [ ] 各画面がスマホサイズ(375px〜420px)で正しく表示されること
- [ ] 名刺カードがMonzoスタイルで中央に表示されること
- [ ] アクションボタン（共有・作り直す）が2カラムで動作すること
- [ ] 全画面のデザインが統一されていること