### PR TITLE
fix: ReceivePageのnullチェック修正（ビルドエラー解消）

### DIFF
--- a/src/pages/ReceivePage.tsx
+++ b/src/pages/ReceivePage.tsx
@@ -32,7 +32,7 @@ export function ReceivePage() {
   }, [searchParams]);
 
   const hasSamePrefectureError =
-    Boolean(myMeishi) && Boolean(meishi) && myMeishi.prefecture === meishi.prefecture;
+    Boolean(myMeishi) && Boolean(meishi) && myMeishi?.prefecture === meishi?.prefecture;
 
   if (error || !meishi) {
     return (


### PR DESCRIPTION
## Summary
- `myMeishi.prefecture` と `meishi.prefecture` がnull可能性でTS18047エラーが発生しデプロイ失敗
- オプショナルチェイニング (`?.`) を追加して修正

## Test plan
- [ ] `npx tsc --noEmit` がエラーなしで通ることを確認
- [ ] デプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)